### PR TITLE
Add invoices.css

### DIFF
--- a/admin/assets/css/invoices.css
+++ b/admin/assets/css/invoices.css
@@ -1,0 +1,3 @@
+a[target="_blank"]::before {
+    display: none;
+}

--- a/admin/src/View/Invoices/HtmlView.php
+++ b/admin/src/View/Invoices/HtmlView.php
@@ -66,6 +66,10 @@ class HtmlView extends BaseHtmlView
         $this->filterForm = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
+        // ✅ Use WebAssetManager to load the script
+        $wa = $this->getDocument()->getWebAssetManager();
+        $wa->registerAndUseStyle('com_mothership.invoices', 'administrator/components/com_mothership/assets/css/invoices.css');
+
         // Ensure transitions is always an array
         $this->transitions = $this->state->get('transitions', []);
         if (!is_array($this->transitions)) {


### PR DESCRIPTION
# Summary
Gets rid of the weird double icons showing for the download and preview pdf.

## Changes
- Fixes #26 
- Adds an `invoices.css` to the admin view all invoices page
- Uses this `invoices.css` to suppress the target blank css