### PR TITLE
Bugfix invoice payment status legend

### DIFF
--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -74,7 +74,6 @@ use Joomla\CMS\Language\Text;
         <li><strong>Opened</strong>: Invoice is awaiting payment.</li>
         <li><strong>Late</strong>: Invoice is past due.</li>
         <li><strong>Paid</strong>: Invoice has been paid.</li>
-        <li><strong>Cancelled</strong>: Invoice has been cancelled.</li>
     </ul>
   </div>
 </div>

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -5,6 +5,11 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Language\Text;
 
 ?>
+<style>
+    .mt-4 {
+        margin-top: 1.5rem;
+    }
+</style>
 <h1>Invoices</h1>
 <table class="table" id="invoicetable">
     <thead>
@@ -60,3 +65,16 @@ use Joomla\CMS\Language\Text;
         <?php endforeach; ?>
     </tbody>
 </table>
+<div class="card mt-4">
+  <div class="card-header">
+    Invoice Status Legend
+  </div>
+  <div class="card-body">
+    <ul class="mb-0">
+        <li><strong>Opened</strong>: Invoice is awaiting payment.</li>
+        <li><strong>Late</strong>: Invoice is past due.</li>
+        <li><strong>Paid</strong>: Invoice has been paid.</li>
+        <li><strong>Cancelled</strong>: Invoice has been cancelled.</li>
+    </ul>
+  </div>
+</div>

--- a/site/tmpl/payments/default.php
+++ b/site/tmpl/payments/default.php
@@ -53,8 +53,8 @@ use Joomla\CMS\Language\Text;
       <li><strong>Pending</strong>: Payment is awaiting confirmation.</li>
       <li><strong>Completed</strong>: Payment was successful.</li>
       <li><strong>Failed</strong>: Payment failed to process.</li>
-      <li><strong>Refunded</strong>: Payment was returned to the payer.</li>
       <li><strong>Cancelled</strong>: Payment was cancelled.</li>
+      <li><strong>Refunded</strong>: Payment was returned to the payer.</li>
     </ul>
   </div>
 </div>

--- a/site/tmpl/payments/default.php
+++ b/site/tmpl/payments/default.php
@@ -5,6 +5,11 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Language\Text;
 
 ?>
+<style>
+    .mt-4 {
+        margin-top: 1.5rem;
+    }
+</style>
 <h1>Payments</h1>
 <table class="table paymentsTable">
     <thead>
@@ -39,3 +44,17 @@ use Joomla\CMS\Language\Text;
         <?php endforeach; ?>
     </tbody>
 </table>
+<div class="card mt-4">
+  <div class="card-header">
+    Payment Status Legend
+  </div>
+  <div class="card-body">
+    <ul class="mb-0">
+      <li><strong>Pending</strong>: Payment is awaiting confirmation.</li>
+      <li><strong>Completed</strong>: Payment was successful.</li>
+      <li><strong>Failed</strong>: Payment failed to process.</li>
+      <li><strong>Refunded</strong>: Payment was returned to the payer.</li>
+      <li><strong>Cancelled</strong>: Payment was cancelled.</li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
# Summary
Adds a status legend to the front end `Invoices` and `Payments` pages so that the user can know what payment status levels are possible.

## Changes
- Fixes #14 
- Fixes #15 