### PR TITLE
Bugfix invoice payment orphan rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The **Invoices** object represents the invoices generated for clients. Each invo
 - **Client ID**: The ID of the client to whom the invoice belongs.
 - **Account ID**: The ID of the account associated with the invoice.
 - **Rate**: The billing rate for the invoice.
-- **Status**: The status of the invoice (e.g., paid, unpaid).
+- **Status**: The status of the invoice (e.g., draft, opened, cancelled, closed).
 - **Total**: The total amount of the invoice.
 - **Due Date**: The date by which the invoice should be paid.
 - **Sent Date**: The date the invoice was sent to the client.
@@ -62,6 +62,12 @@ The **Invoices** object represents the invoices generated for clients. Each invo
 - **Created By**: The ID of the user who created the invoice.
 - **Checked Out Time**: The timestamp when the invoice record was last checked out.
 - **Checked Out**: The ID of the user who last checked out the invoice record.
+
+### Invoice Lifecycle Status Levels
+- **Draft**: The invoice is being created and is not yet finalized.
+- **Opened**: The invoice has been finalized and sent to the client and is awaiting payment.
+- **Cancelled**: The invoice has been cancelled and is no longer valid.
+- **Closed**: The invoice has been paid and is considered complete.
 
 ## Invoice Items
 The **Invoice Items** object represents the individual items listed on an invoice. Each invoice item has the following attributes:

--- a/README.md
+++ b/README.md
@@ -144,11 +144,16 @@ This payment method is essentially a digital version of "Pay by Check". Once the
 
 ## Invoice Helper
 - **getStatus($status_id)**: Retrieves the status details for the given status ID.
+- **isLate($invoice_id)**: 
+- **getDueString(int $invoice_id)**:
+- **getDueStringFromDate(?string $dueDate)**:
 - **setInvoiceClosed($invoiceId)**: Marks the specified invoice as paid.
 - **getInvoiceAppliedPayments($invoiceID)**: Retrieves all payments applied to the specified invoice.
 - **sumInvoiceAppliedPayments($invoiceId)**: Calculates the total amount of payments applied to the specified invoice.
 - **updateInvoiceStatus($invoiceId, $status)**: Updates the status of the specified invoice.
 - **getInvoice($invoice_id)**: Retrieves the details of the specified invoice.
+- **recalculateInvoiceStatusrecalculateInvoiceStatus(int $invoiceId)**:
+
 
 ## Payments Helper
 The **Payments Helper** provides several methods to manage and update payment records and statuses. Below are the methods available:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ This payment method is essentially a digital version of "Pay by Check". Once the
 
 ## Invoice Helper
 - **getStatus($status_id)**: Retrieves the status details for the given status ID.
-- **setInvoicePaid($invoiceId)**: Marks the specified invoice as paid.
+- **setInvoiceClosed($invoiceId)**: Marks the specified invoice as paid.
 - **getInvoiceAppliedPayments($invoiceID)**: Retrieves all payments applied to the specified invoice.
 - **sumInvoiceAppliedPayments($invoiceId)**: Calculates the total amount of payments applied to the specified invoice.
 - **updateInvoiceStatus($invoiceId, $status)**: Updates the status of the specified invoice.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,56 @@ The **Invoice Payments** object represents payments that are applied to specific
 ## Payment Plugins
 There are two payment plugins: Paypal and Zelle. The payment plugin type is 'Mothership Payments'.
 
+### Creating a Payment Plugin
+To create a Mothership Payment plugin, follow these steps:
+
+1. **Create the Plugin Directory**: Create a new directory for your plugin under the `plugins/mothership-payment` directory. Name the directory according to your payment method, e.g., `mypaymentmethod`.
+
+2. **Create the Plugin Files**: Inside your plugin directory, create the following files:
+    - `mypaymentmethod.php`: This is the main plugin file.
+    - `mypaymentmethod.xml`: This is the manifest file that describes your plugin.
+
+3. **Define the Plugin Class**: In `mypaymentmethod.php`, define a class that extends `MothershipPaymentsPlugin`. Implement the required methods for processing payments.
+
+    ```php
+    defined('_JEXEC') or die;
+
+    class PlgMothershipPaymentsmypaymentmethod extends MothershipPaymentsPlugin
+    {
+         public function onMothershipPaymentRequest($paymentData)
+         {
+              // Implement your payment processing logic here
+         }
+
+         public function onAfterInitialiseMothership()
+         {
+              // Any initialization code for your plugin
+         }
+    }
+    ```
+
+4. **Create the Manifest File**: In `mypaymentmethod.xml`, define the plugin metadata and files.
+
+    ```xml
+    <extension type="plugin" group="mothershippayments" method="upgrade">
+         <name>PLG_MOTHERSHIPPAYMENTS_mypaymentmethod</name>
+         <author>Your Name</author>
+         <version>1.0.0</version>
+         <description>My custom payment plugin for Mothership</description>
+         <files>
+              <filename plugin="mypaymentmethod">mypaymentmethod.php</filename>
+         </files>
+    </extension>
+    ```
+
+5. **Install and Enable the Plugin**: Install the plugin through the Joomla Extension Manager and enable it from the Plugin Manager.
+
+6. **Configure the Plugin**: Add any necessary configuration options in the plugin settings to allow users to enter their payment gateway credentials.
+
+By following these steps, you can create a custom payment plugin for Mothership that integrates with your preferred payment gateway.
+
 ### PayPal
+This payment method allows clients to pay invoices using PayPal. Once the payment is completed, the status of the payment will be automatically updated to confirmed.
 
 ### Zelle
 This payment method is essentially a digital version of "Pay by Check". Once the payment has been confirmed, an administrator will need to manually update the status of the payment to confirmed.

--- a/admin/src/Helper/InvoiceHelper.php
+++ b/admin/src/Helper/InvoiceHelper.php
@@ -47,22 +47,42 @@ class InvoiceHelper
         return $status;
     }
 
-    public static function isLate($invoice_id)
+    public static function isLate(int $invoiceId): bool
     {
         $db = Factory::getContainer()->get(DatabaseDriver::class);
         $query = $db->getQuery(true)
             ->select('due_date')
             ->from($db->quoteName('#__mothership_invoices'))
-            ->where($db->quoteName('id') . ' = ' . (int) $invoice_id);
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $invoiceId, ParameterType::INTEGER);
+
         $db->setQuery($query);
         $dueDate = $db->loadResult();
 
-        if (strtotime($dueDate) < strtotime(date('Y-m-d'))) {
+        if (!$dueDate) {
+            return false;
+        }
+
+        $timezone = new \DateTimeZone('America/Los_Angeles');
+
+        $now = new \DateTimeImmutable('now', $timezone);
+        $due = (new \DateTimeImmutable($dueDate))->setTimezone($timezone);
+
+        // If due date is before today, definitely late
+        if ($due->format('Y-m-d') < $now->format('Y-m-d')) {
             return true;
         }
 
+        // If due date is today, allow a 60-second grace window
+        if ($due->format('Y-m-d') === $now->format('Y-m-d')) {
+            return $now->getTimestamp() > ($due->getTimestamp() + 60);
+        }
+
+        // Due in the future
         return false;
     }
+
+
 
     public static function getDueString(int $invoice_id): string
     {

--- a/admin/src/Helper/InvoiceHelper.php
+++ b/admin/src/Helper/InvoiceHelper.php
@@ -90,7 +90,7 @@ class InvoiceHelper
     }
 
 
-    public static function setInvoicePaid($invoiceId)
+    public static function setInvoiceClosed($invoiceId)
     {
         self::updateInvoiceStatus($invoiceId, 4);
     }

--- a/admin/src/Helper/InvoiceHelper.php
+++ b/admin/src/Helper/InvoiceHelper.php
@@ -77,11 +77,13 @@ class InvoiceHelper
         // Due in x days 
         $dueString = '';
         if (strtotime($dueDate) > strtotime(date('Y-m-d'))) {
-            $dueString = 'Due in ' . (strtotime($dueDate) - strtotime(date('Y-m-d'))) / 86400 . ' days';
+            $days = (int) floor((strtotime($dueDate) - strtotime(date('Y-m-d'))) / 86400);
+            $dueString = "Due in {$days} days";
         }
         else if(strtotime($dueDate) < strtotime(date('Y-m-d'))) {
             // x days late
-            $dueString = (strtotime(date('Y-m-d')) - strtotime($dueDate)) / 86400 . ' days late';
+            $daysLate = (int) ((strtotime(date('Y-m-d')) - strtotime($dueDate)) / 86400);
+            $dueString = "{$daysLate} days late";
         }
 
         return $dueString;
@@ -214,10 +216,8 @@ class InvoiceHelper
         // Determine new status
         $status = 2; // e.g. 0 = Opened
         if ($totalPaid >= $invoiceTotal) {
-            $status = 4; // Paid
-        } elseif ($totalPaid > 0) {
-            $status = 5; // Partially Paid
-        }
+            $status = 4; // Closed
+        } 
 
         // Update invoice status
         $query = $db->getQuery(true)

--- a/admin/src/Helper/PaymentHelper.php
+++ b/admin/src/Helper/PaymentHelper.php
@@ -21,9 +21,68 @@ use Joomla\Database\DatabaseDriver;
 use TrevorBice\Component\Mothership\Administrator\Helper\ClientHelper;
 use TrevorBice\Component\Mothership\Administrator\Helper\AccountHelper;
 use TrevorBice\Component\Mothership\Administrator\Helper\InvoiceHelper;
+use Joomla\Database\ParameterType;
 
 class PaymentHelper
 {
+
+     /**
+     * Recalculates the status of an invoice based on the total payments made.
+     *
+     * This method retrieves the total amount paid for a given invoice and compares it to the invoice total.
+     * It then updates the invoice status to one of the following:
+     * - 0: Unpaid
+     * - 1: Partially Paid
+     * - 2: Paid
+     *
+     * @param int $invoiceId The ID of the invoice to recalculate the status for.
+     *
+     * @return void
+     */
+    public static function recalculateInvoiceStatus(int $invoiceId): void
+    {
+        $db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        // Calculate total payments for this invoice
+        $query = $db->getQuery(true)
+            ->select('SUM(p.amount)')
+            ->from($db->quoteName('#__mothership_invoice_payment', 'ip'))
+            ->join('INNER', $db->quoteName('#__mothership_payments', 'p')
+                . ' ON ' . $db->quoteName('ip.payment_id') . ' = ' . $db->quoteName('p.id'))
+            ->where($db->quoteName('ip.invoice_id') . ' = :invoiceId')
+            ->bind(':invoiceId', $invoiceId, ParameterType::INTEGER);
+
+        $db->setQuery($query);
+        $totalPaid = (float) $db->loadResult();
+
+        // Load invoice total
+        $query = $db->getQuery(true)
+            ->select('total')
+            ->from($db->quoteName('#__mothership_invoices'))
+            ->where($db->quoteName('id') . ' = :invoiceId')
+            ->bind(':invoiceId', $invoiceId, ParameterType::INTEGER);
+
+        $db->setQuery($query);
+        $invoiceTotal = (float) $db->loadResult();
+
+        // Determine new status
+        $status = 0; // e.g. 0 = Unpaid
+        if ($totalPaid >= $invoiceTotal) {
+            $status = 2; // Paid
+        } elseif ($totalPaid > 0) {
+            $status = 1; // Partially Paid
+        }
+
+        // Update invoice status
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__mothership_invoices'))
+            ->set($db->quoteName('status') . ' = :status')
+            ->where($db->quoteName('id') . ' = :invoiceId')
+            ->bind(':status', $status, ParameterType::INTEGER)
+            ->bind(':invoiceId', $invoiceId, ParameterType::INTEGER);
+        $db->setQuery($query);
+        $db->execute();
+    }
 
     public static function getPayment($paymentId)
     {

--- a/plugins/mothership-payment/paypal/paypal.php
+++ b/plugins/mothership-payment/paypal/paypal.php
@@ -198,7 +198,7 @@ class PlgMothershipPaymentPaypal extends CMSPlugin
         $invoice_id = $app->input->getInt('invoice', 0);
         $mc_gross = $app->input->getFloat('mc_gross', 0);
         $mc_fee = $app->input->getFloat('mc_fee', 0);
-
+        
         switch ($payment_status) {
             case 'Completed':
                 try {

--- a/plugins/mothership-payment/paypal/paypal.php
+++ b/plugins/mothership-payment/paypal/paypal.php
@@ -217,8 +217,10 @@ class PlgMothershipPaymentPaypal extends CMSPlugin
                 // Use the PaymentHelper to record the payment and invoice mapping
                 $payment_method = "paypal";
                 $status = 2;
+
+                
                 try {
-                    PaymentHelper::insertPaymentRecord(
+                    $payment_id = PaymentHelper::insertPaymentRecord(
                         $client_id,
                         $account_id,
                         $mc_gross,
@@ -229,11 +231,19 @@ class PlgMothershipPaymentPaypal extends CMSPlugin
                         $txn_id,
                         $status
                     );
+
+                    $invoicePaymentId = PaymentHelper::insertInvoicePayments($invoice_id, $payment_id, $mc_gross);
+                    if (!$invoicePaymentId) {
+                        throw new \RuntimeException("insertInvoicePayments() failed");
+                    }
+
                 } catch (\Exception $e) {
                     // log the error
                     echo "Failed to store payment:" . $e->getMessage();
                     exit();
+                
                 }
+
                 exit('IPN Received');
                 break;
             case 'Pending':

--- a/plugins/mothership-payment/paypal/paypal.php
+++ b/plugins/mothership-payment/paypal/paypal.php
@@ -212,7 +212,7 @@ class PlgMothershipPaymentPaypal extends CMSPlugin
                 $account_id = $invoice->account_id;
 
                 // Set the invoice to be paid
-                InvoiceHelper::setInvoicePaid($invoice_id);
+                InvoiceHelper::setInvoiceClosed($invoice_id);
 
                 // Use the PaymentHelper to record the payment and invoice mapping
                 $payment_method = "paypal";


### PR DESCRIPTION
# Summary
Fixes the bug with orphaned rows in the `mothership_invoice_payment` table. Also starts to separate concerns in the invoice status.

## Changes
- Removes `Late` as a stored lifecycle status and replaces it with `Cancelled`
- Introduces a new `isLate($invoice_id)` helper to determine if an invoice is past its due date
- Adds `getDueString($invoice_id)` for friendly UI strings like "Due in 3 days" or "5 days late"
- Adds `recalculateInvoiceStatus($invoice_id)` to update an invoice's lifecycle status when payments change
