### PR TITLE
Bugfix orphaned clients accounts

### DIFF
--- a/admin/src/Controller/AccountsController.php
+++ b/admin/src/Controller/AccountsController.php
@@ -55,22 +55,64 @@ class AccountsController extends BaseController
     {
         $app   = Factory::getApplication();
         $input = $app->input;
+        $db    = Factory::getDbo();
 
-        // Get the list of IDs from the request.
         $ids = $input->get('cid', [], 'array');
 
         if (empty($ids)) {
             $app->enqueueMessage(Text::_('JGLOBAL_NO_ITEM_SELECTED'), 'warning');
         } else {
-            $model = $this->getModel('Accounts');
-            if ($model->delete($ids)) {
-                $app->enqueueMessage(Text::sprintf('COM_MOTHERSHIP_ACCOUNT_DELETE_SUCCESS', count($ids), count($ids) > 1 ? 's' : ''), 'message');
-            } else {
-                $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ACCOUNT_DELETE_FAILED'), 'error');
+            $blocked = [];
+            $allowed = [];
+
+            foreach ($ids as $accountId) {
+                $accountId = (int) $accountId;
+
+                // Check for related invoices
+                $query = $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from('#__mothership_invoices')
+                    ->where('account_id = ' . $accountId);
+                $db->setQuery($query);
+                $invoiceCount = (int) $db->loadResult();
+
+                // Check for related payments
+                $query->clear()
+                    ->select('COUNT(*)')
+                    ->from('#__mothership_payments')
+                    ->where('account_id = ' . $accountId);
+                $db->setQuery($query);
+                $paymentCount = (int) $db->loadResult();
+
+                if ($invoiceCount > 0 || $paymentCount > 0) {
+                    $blocked[] = $accountId;
+                } else {
+                    $allowed[] = $accountId;
+                }
+            }
+
+            if (!empty($allowed)) {
+                $model = $this->getModel('Accounts');
+                if ($model->delete($allowed)) {
+                    $app->enqueueMessage(
+                        Text::sprintf('COM_MOTHERSHIP_ACCOUNT_DELETE_SUCCESS', count($allowed), count($allowed) === 1 ? '' : 's'),
+                        'message'
+                    );
+                } else {
+                    $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ACCOUNT_DELETE_FAILED'), 'error');
+                }
+            }
+
+            if (!empty($blocked)) {
+                $app->enqueueMessage(
+                    Text::sprintf('COM_MOTHERSHIP_ACCOUNT_DELETE_HAS_DEPENDENCIES', implode(', ', $blocked)),
+                    'warning'
+                );
             }
         }
 
         $this->setRedirect(Route::_('index.php?option=com_mothership&view=accounts', false));
     }
+
 
 }

--- a/admin/src/Controller/AccountsController.php
+++ b/admin/src/Controller/AccountsController.php
@@ -68,7 +68,7 @@ class AccountsController extends BaseController
             foreach ($ids as $accountId) {
                 $accountId = (int) $accountId;
 
-                // Check for related invoices
+                // Check for related invoices only
                 $query = $db->getQuery(true)
                     ->select('COUNT(*)')
                     ->from('#__mothership_invoices')
@@ -76,15 +76,7 @@ class AccountsController extends BaseController
                 $db->setQuery($query);
                 $invoiceCount = (int) $db->loadResult();
 
-                // Check for related payments
-                $query->clear()
-                    ->select('COUNT(*)')
-                    ->from('#__mothership_payments')
-                    ->where('account_id = ' . $accountId);
-                $db->setQuery($query);
-                $paymentCount = (int) $db->loadResult();
-
-                if ($invoiceCount > 0 || $paymentCount > 0) {
+                if ($invoiceCount > 0) {
                     $blocked[] = $accountId;
                 } else {
                     $allowed[] = $accountId;


### PR DESCRIPTION
# Summary
Fixes the issues with orphaned rows and deleting clients and accounts by restricting deletes and warning messages.

## Changes
- Fixes #9 
- Fixes #10 
- `Clients` cannot be deleted if there are associated `Accounts` or associated `Payments`
- `Accounts` cannot be deleted if there are associated `Invoices`
- Deleting `Accounts` will set the `account_id` field in `Payments` to NULL which will cause them to default to the `Client`
- Payments can only be deleted in the `Draft` state
- Deleting a `payment` will result in deleting the `invoice payment` as well and re-assessing the invoice status
- `Invoices` cannot be deleted unless they are are in the `Draft` state
- Deleting `Invoices` will also delete `mothership_invoice_payment` rows.