### PR TITLE
Bugfix: Fix all the status levels being displayed

### DIFF
--- a/admin/src/Helper/InvoiceHelper.php
+++ b/admin/src/Helper/InvoiceHelper.php
@@ -262,4 +262,8 @@ class InvoiceHelper
         $db->execute();
     }
 
+    public function getInvoicePayments($invoiceId)
+    {
+        
+    }
 }

--- a/admin/src/Helper/PaymentHelper.php
+++ b/admin/src/Helper/PaymentHelper.php
@@ -250,4 +250,22 @@ class PaymentHelper
         return $invoice_payment_id;
     }
 
+    public function getPaymentInvoices($paymentId)
+    {
+        $db = Factory::getContainer()->get(DatabaseDriver::class);
+        $query = $db->getQuery(true)
+            ->select('invoice_id, applied_amount')
+            ->from($db->quoteName('#__mothership_invoice_payment'))
+            ->where($db->quoteName('payment_id') . ' = ' . (int) $paymentId);
+        $db->setQuery($query);
+
+        try {
+            $invoices = $db->loadObjectList();
+        } catch (\Exception $e) {
+            throw new \RuntimeException("Failed to get payment invoices: " . $e->getMessage());
+        }
+
+        return $invoices;
+    }
+
 }

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -123,8 +123,15 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                         <?php echo $item->status; ?>
                                     </td>
                                     <td>
-                                        Completed<br/>
-                                        <small><a href="#">Payment #21</a></small>
+                                        <?php echo $item->payment_status; ?><br/>
+                                        <?php $payment_ids = explode(",",$item->payment_ids); ?>
+                                        <?php if (count($payment_ids) > 1): ?>
+                                        <ul style="margin-bottom:0px;">
+                                            <?php foreach ($payment_ids as $paymentId): ?>
+                                                <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=payment&layout=edit&id=<?php echo $paymentId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=invoices')); ?>"><?php echo "Payment #" . str_pad($paymentId, 2, "0", STR_PAD_LEFT); ?></a></small></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                        <?php endif; ?>
                                     </td>
                                     <td>
                                         <?php echo !empty($item->due) ? $item->due : 'N/A'; ?>

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -123,7 +123,8 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                         <?php echo $item->status; ?>
                                     </td>
                                     <td>
-                                        <?php echo $item->payment_status; ?>
+                                        Completed<br/>
+                                        <small><a href="#">Payment #21</a></small>
                                     </td>
                                     <td>
                                         <?php echo !empty($item->due) ? $item->due : 'N/A'; ?>

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -67,6 +67,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                 </th>
 
                                 <th scope="col" class="w-10">
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_PAYMENT_STATUS', 'i.payment_status', $listDirn, $listOrder); ?>
+                                </th>
+
+                                <th scope="col" class="w-10">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_DUE', 'i.due', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="w-10">
@@ -117,6 +121,9 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php echo $item->status; ?>
+                                    </td>
+                                    <td>
+                                        <?php echo $item->payment_status; ?>
                                     </td>
                                     <td>
                                         <?php echo !empty($item->due) ? $item->due : 'N/A'; ?>

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -124,8 +124,8 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php echo $item->payment_status; ?><br/>
-                                        <?php $payment_ids = explode(",",$item->payment_ids); ?>
-                                        <?php if (count($payment_ids) > 1): ?>
+                                        <?php $payment_ids = array_filter(explode(",", $item->payment_ids)); ?>
+                                        <?php if (count($payment_ids) > 0): ?>
                                         <ul style="margin-bottom:0px;">
                                             <?php foreach ($payment_ids as $paymentId): ?>
                                                 <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=payment&layout=edit&id=<?php echo $paymentId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=invoices')); ?>"><?php echo "Payment #" . str_pad($paymentId, 2, "0", STR_PAD_LEFT); ?></a></small></li>

--- a/admin/tmpl/payments/default.php
+++ b/admin/tmpl/payments/default.php
@@ -103,7 +103,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                         <?php echo HTMLHelper::_('date', $item->created_at, Text::_('DATE_FORMAT_LC4')); ?>
                                     </td>
                                     <td>
-                                        <?php echo $item->status; ?>
+                                        <?php echo $item->status; ?><br/>
+                                        <small><a href="#">Invoice #1</a></small>
                                     </td>
                                     <td>
                                         <a href="<?php echo Route::_("index.php?option=com_mothership&view=invoicepayments&payment_id={$item->id}"); ?>" title="<?php echo Text::_('COM_MOTHERSHIP_PAYMENT_MANAGE_ALLOCATIONS'); ?>">

--- a/admin/tmpl/payments/default.php
+++ b/admin/tmpl/payments/default.php
@@ -68,8 +68,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                         </thead>
                         <tbody>
                             <?php foreach ($this->items as $i => $item):
-                                $user       = Factory::getApplication()->getIdentity();
-                                $canEdit    = $user->authorise('core.edit', "com_mothership.payment.{$item->id}");
+                                $user = Factory::getApplication()->getIdentity();
+                                $canEdit = $user->authorise('core.edit', "com_mothership.payment.{$item->id}");
                                 $canEditOwn = $user->authorise('core.edit.own', "com_mothership.payment.{$item->id}");
                                 $canCheckin = $user->authorise('core.manage', 'com_mothership');
                             ?>

--- a/admin/tmpl/payments/default.php
+++ b/admin/tmpl/payments/default.php
@@ -104,7 +104,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php echo $item->status; ?><br/>
-                                        <small><a href="#">Invoice #1</a></small>
+                                        <?php $invoice_ids = array_filter(explode(",", $item->invoice_ids)); ?>
+                                        <?php if (count($invoice_ids) > 0): ?>
+                                        <ul style="margin-bottom:0px;">
+                                            <?php foreach ($invoice_ids as $invoiceId): ?>
+                                                <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=invoice&layout=edit&id=<?php echo $invoiceId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=payments')); ?>"><?php echo "Invoice #" . $invoiceId; ?></a></small></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                        <?php endif; ?>
                                     </td>
                                     <td>
                                         <a href="<?php echo Route::_("index.php?option=com_mothership&view=invoicepayments&payment_id={$item->id}"); ?>" title="<?php echo Text::_('COM_MOTHERSHIP_PAYMENT_MANAGE_ALLOCATIONS'); ?>">

--- a/site/src/Model/InvoicesModel.php
+++ b/site/src/Model/InvoicesModel.php
@@ -21,23 +21,51 @@ class InvoicesModel extends ListModel
         }
 
         $db = $this->getDbo();
-        $query = $db->getQuery(true)
-            ->select(
-                'i.*, a.name AS account_name, ' .
-                'CASE ' . $db->quoteName('i.status') . 
-                    ' WHEN 1 THEN ' . $db->quote('Draft') . 
-                    ' WHEN 2 THEN ' . $db->quote('Opened') . 
-                    ' WHEN 3 THEN ' . $db->quote('Late') . 
-                    ' WHEN 4 THEN ' . $db->quote('Paid') .
-                    ' ELSE ' . $db->quote('Unknown') . ' END AS ' . $db->quoteName('status')
-                )
-            ->from('#__mothership_invoices AS i')
-            ->join('LEFT', '#__mothership_accounts AS a ON i.client_id = a.client_id')
-            ->where("i.status != '1'")
-            ->where("i.client_id = '{$clientId}'");
+        $query = $db->getQuery(true);
+        $query->select([
+            'i.*',
+            'a.name AS account_name',
+    
+            // Lifecycle status
+            'CASE ' . $db->quoteName('i.status') .
+                ' WHEN 1 THEN ' . $db->quote('Draft') .
+                ' WHEN 2 THEN ' . $db->quote('Opened') .
+                ' WHEN 3 THEN ' . $db->quote('Cancelled') .
+                ' WHEN 4 THEN ' . $db->quote('Closed') .
+                ' ELSE ' . $db->quote('Unknown') . ' END AS status',
+    
+            // Payment data
+            'COALESCE(pay.total_paid, 0) AS total_paid',
+            'pay.payment_ids',
+            'CASE' .
+                ' WHEN COALESCE(pay.total_paid, 0) <= 0 THEN ' . $db->quote('Unpaid') .
+                ' WHEN COALESCE(pay.total_paid, 0) < i.total THEN ' . $db->quote('Partially Paid') .
+                ' ELSE ' . $db->quote('Paid') .
+            ' END AS payment_status'
+        ]);
+    
+        $query->from($db->quoteName('#__mothership_invoices', 'i'))
+            ->join('LEFT', '#__mothership_accounts AS a ON i.account_id = a.id')
+    
+            // 👇 JOIN payment info like in backend
+            ->join(
+                'LEFT',
+                '(SELECT ip.invoice_id,
+                         SUM(ip.applied_amount) AS total_paid,
+                         GROUP_CONCAT(p.id ORDER BY p.payment_date) AS payment_ids
+                  FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip') . '
+                  JOIN ' . $db->quoteName('#__mothership_payments', 'p') . ' ON ip.payment_id = p.id
+                  WHERE p.status = 2
+                  GROUP BY ip.invoice_id) AS pay
+                  ON pay.invoice_id = i.id'
+            )
+    
+            ->where($db->quoteName('i.status') . ' != 1')
+            ->where($db->quoteName('i.client_id') . ' = :clientId')
+            ->bind(':clientId', $clientId, \Joomla\Database\ParameterType::INTEGER);
+    
         $db->setQuery($query);
-        
-
+    
         return $db->loadObjectList();
     }
 }

--- a/site/src/Model/PaymentModel.php
+++ b/site/src/Model/PaymentModel.php
@@ -17,17 +17,48 @@ class PaymentModel extends BaseDatabaseModel
 
         $db = $this->getDatabase();
 
-        // Load the payment
+        // Load the payment with status and related invoices
         $query = $db->getQuery(true)
-            ->select('*')
-            ->from('#__mothership_payments')
-            ->where('id = ' . (int) $id)
-            ->where('status != -1');
+            ->select([
+                'p.*',
+
+                // Interpreted status
+                'CASE ' . $db->quoteName('p.status') .
+                    ' WHEN 1 THEN ' . $db->quote('Pending') .
+                    ' WHEN 2 THEN ' . $db->quote('Completed') .
+                    ' WHEN 3 THEN ' . $db->quote('Failed') .
+                    ' WHEN 4 THEN ' . $db->quote('Cancelled') .
+                    ' WHEN 5 THEN ' . $db->quote('Refunded') .
+                    ' ELSE ' . $db->quote('Unknown') .
+                ' END AS status_text',
+
+                // Related invoice info
+                'inv.invoice_ids',
+                'inv.invoice_numbers'
+            ])
+            ->from($db->quoteName('#__mothership_payments', 'p'))
+
+            ->join(
+                'LEFT',
+                '(SELECT ip.payment_id,
+                        GROUP_CONCAT(ip.invoice_id ORDER BY ip.invoice_id) AS invoice_ids,
+                        GROUP_CONCAT(i.number ORDER BY ip.invoice_id) AS invoice_numbers
+                FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip') . '
+                JOIN ' . $db->quoteName('#__mothership_invoices', 'i') . ' ON ip.invoice_id = i.id
+                GROUP BY ip.payment_id) AS inv
+                ON inv.payment_id = p.id'
+            )
+
+            ->where('p.id = :id')
+            ->where('p.status != -1')
+            ->bind(':id', $id, \Joomla\Database\ParameterType::INTEGER);
+
         $db->setQuery($query);
         $payment = $db->loadObject();
 
         return $payment;
     }
+
 
     protected function populateState()
     {

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
             <th>Account</th>
             <th>Amount</th>
             <th>Status</th>
+            <th>Payment Status</th>
             <th>Due Date</th>
             <th>Actions</th>
         </tr>
@@ -26,7 +27,7 @@ use Joomla\CMS\Language\Text;
     <tbody>
         <?php if(empty($this->invoices)) : ?>
             <tr>
-                <td colspan="7">No invoices found.</td>
+                <td colspan="8">No invoices found.</td>
             </tr>
         <?php endif; ?>
         <?php foreach ($this->invoices as $invoice) : ?>
@@ -38,6 +39,17 @@ use Joomla\CMS\Language\Text;
                 <td><?php echo $invoice->account_name; ?></td>
                 <td>$<?php echo number_format($invoice->total, 2); ?></td>
                 <td><?php echo $invoice->status; ?></td>
+                <td>
+                    <?php echo $invoice->payment_status; ?><br/>
+                    <?php $payment_ids = array_filter(explode(",", $invoice->payment_ids)); ?>
+                    <?php if (count($payment_ids) > 0): ?>
+                    <ul style="margin-bottom:0px;">
+                        <?php foreach ($payment_ids as $paymentId): ?>
+                            <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=payment&id=<?php echo $paymentId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=invoices')); ?>"><?php echo "Payment #" . str_pad($paymentId, 2, "0", STR_PAD_LEFT); ?></a></small></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <?php endif; ?>
+                </td>
                 <td>
                     <?php if($invoice->status === 'Opened' || $invoice->status === 'Late'): ?>
                     <?php

--- a/site/tmpl/payment/default.php
+++ b/site/tmpl/payment/default.php
@@ -1,14 +1,64 @@
 <?php
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Layout\FileLayout;
+use Joomla\CMS\Router\Route;
 
-$invoice = isset($this->item) ? $this->item : null;
+$payment = $this->item;
+?>
 
-if (!$invoice) {
-    echo '<div class="alert alert-warning">Invoice not found.</div>';
-    return;
-}
+<div class="container my-4">
+    <div class="card shadow-sm">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+            <h4 class="mb-0">Payment #<?php echo $payment->id; ?></h4>
+            <span class="badge bg-light text-dark"><?php echo htmlspecialchars($payment->payment_method); ?></span>
+        </div>
+        <div class="card-body">
+            <p>
+                <strong>Amount:</strong>
+                <span class="text-success fw-bold">$<?php echo number_format($payment->amount, 2); ?></span>
+            </p>
 
-$layout = new FileLayout('pdf', JPATH_ROOT . '/components/com_mothership/layouts');
-echo $layout->render(['invoice' => $invoice]);
+            <p>
+                <strong>Status:</strong>
+                <?php
+                    $statusColor = match ((int) $payment->status) {
+                        1 => 'warning',
+                        2 => 'success',
+                        3 => 'danger',
+                        4 => 'secondary',
+                        5 => 'info',
+                        default => 'dark',
+                    };
+                ?>
+                <span class="badge bg-<?php echo $statusColor; ?>">
+                    <?php echo $payment->status_text ?? $payment->status; ?>
+                </span>
+            </p>
+
+            <p>
+                <strong>Payment Date:</strong>
+                <?php echo htmlspecialchars($payment->payment_date); ?>
+            </p>
+
+            <?php if (!empty($payment->invoice_ids)) : ?>
+                <hr>
+                <p><strong>Invoices Paid With This Payment:</strong></p>
+                <ul class="list-group list-group-flush">
+                    <?php
+                    $ids = explode(',', $payment->invoice_ids);
+                    $numbers = explode(',', $payment->invoice_numbers);
+                    foreach ($ids as $i => $invoiceId) :
+                        $number = $numbers[$i] ?? $invoiceId;
+                        $url = Route::_('index.php?option=com_mothership&view=invoice&id=' . (int) $invoiceId);
+                    ?>
+                        <li class="list-group-item">
+                            <a href="<?php echo $url; ?>">
+                                Invoice #<?php echo htmlspecialchars($number); ?>
+                            </a>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>

--- a/site/tmpl/payments/default.php
+++ b/site/tmpl/payments/default.php
@@ -32,7 +32,7 @@ use Joomla\CMS\Language\Text;
         <?php endif; ?>
         <?php foreach ($this->payments as $payment) : ?>
             <tr>
-                <td><a href="<?php echo Route::_('index.php?option=com_mothership&view=payment&id=' . $payment->id); ?>"><?php echo $payment->number; ?></a></td>
+                <td><a href="<?php echo Route::_('index.php?option=com_mothership&view=payment&id=' . $payment->id); ?>"><?php echo $payment->id; ?></a></td>
                 <td><?php echo $payment->account_name; ?></td>
                 <td>$<?php echo number_format($payment->amount, 2); ?></td>
                 <td><?php echo $payment->status; ?></td>


### PR DESCRIPTION
# Summary

This PR separates the invoice **lifecycle status** (e.g. Draft, Opened) from the **payment status** (e.g. Unpaid, Paid), and improves visibility of the relationships between payments and invoices across both admin and frontend views. Payments now display the invoices they cover, and invoices display the payments applied to them.

This enhances clarity for users, ensures accurate financial status tracking, and improves data integrity across the application.

# Related Issues

- Fixes #59
- Implements feature request from #55

# Changes

- ✅ Adds a new frontend `Payment` view for displaying detailed payment information
- ✅ Adds `payment_status` to **frontend `Invoices`** view, calculated directly via MySQL:
  - `Unpaid`: No payments applied
  - `Partially Paid`: Payments applied, but total is less than invoice total
  - `Paid`: Applied payments meet or exceed invoice total
- ✅ Adds related invoice list to **frontend `Payments`** view, including clickable links
- ✅ Adds `payment_status` to **admin `Invoices`** list view using the same SQL logic
- ✅ Adds list of related invoices to **admin `Payments`** list view
- ✅ Ensures `payment_status` is calculated fully in MySQL for performance and accuracy

# Technical Notes

- Payment-to-invoice associations are managed through the `#__mothership_invoice_payment` table
- `payment_status` is **not stored**, only calculated dynamically in queries
- Payment status is **not the same** as invoice lifecycle status (i.e., an invoice can be `Closed` but still `Unpaid`)

