### PR TITLE
Bugfix: default rate

### DIFF
--- a/admin/assets/js/invoice-edit.js
+++ b/admin/assets/js/invoice-edit.js
@@ -348,8 +348,8 @@ jQuery(document).ready(function ($) {
                 console.log('Success Default rate:', data.default_rate);
                 if (typeof data.default_rate !== 'undefined') {
                     $rateField.val(data.default_rate);
-                    // Also needs to loop through the 
-                    // Loop through the invoice item rates and update them
+                    // Also needs to loop through the invoice item rates
+                    // and update them with the default rate from the client.
                     $('#invoice-items-table tbody tr').each(function () {
                         const rateInput = $(this).find('input[name$="[rate]"]');
                         rateInput.val(data.default_rate);

--- a/admin/assets/js/invoice-edit.js
+++ b/admin/assets/js/invoice-edit.js
@@ -120,58 +120,55 @@ jQuery(document).ready(function ($) {
         quantityToHoursMinutes(this);
         updateSubtotal(this);
     });
-});
 
+    /**
+     * Mothership Invoice - Dynamic Account Dropdown Handler
+     *
+     * This script is used in the Joomla 5 admin interface of the Mothership component.
+     * It controls the visibility and population of the "Account" dropdown based on the selected "Client".
+     *
+     * Behavior Overview:
+     * ------------------
+     * - On initial page load:
+     *   - If no client is selected (value is ''), the Account field (.account_id_wrapper) is hidden.
+     *   - The loading spinner (.account-loading-spinner) is also hidden.
+     *
+     * - When a client is selected:
+     *   1. The Account field slides open over 200ms.
+     *   2. A loading spinner fades in over 200ms, centered in the account container.
+     *   3. An AJAX request is sent to:
+     *      /administrator/index.php?option=com_mothership&task=invoice.getAccountsList&client_id={clientId}
+     *   4. While waiting, the Account dropdown is hidden.
+     *   5. On AJAX success:
+     *      - The Account dropdown is cleared and populated with the returned list.
+     *      - Each item is an object with { value, text, disable }.
+     *      - The spinner fades out (200ms), and the dropdown fades in (200ms).
+     *
+     * - If the user selects a blank client:
+     *   - The Account section fades out and slides closed over 200ms.
+     *   - The spinner is reset and hidden.
+     *
+     * Expected JSON response format:
+     * ------------------------------
+     * [
+     *   { "value": "", "text": "Please select an Account", "disable": false },
+     *   { "value": 1,  "text": "Test Account",             "disable": false }
+     * ]
+     *
+     * Security Considerations:
+     * ------------------------
+     * - CSRF protection should be implemented via Joomla.getOptions('csrf.token') and validated in PHP.
+     * - Server-side must validate user permissions and input (client_id).
+     * - The PHP controller should return a proper JsonResponse object.
+     *
+     * DOM Elements:
+     * -------------
+     * - #jform_client_id            : Client dropdown
+     * - .account_id_wrapper         : Wrapper for the Account dropdown (shown/hidden)
+     * - .account-loading-spinner    : Spinner shown during AJAX load
+     * - #jform_account_id           : Account dropdown (populated dynamically)
+     */
 
-/**
- * Mothership Invoice - Dynamic Account Dropdown Handler
- *
- * This script is used in the Joomla 5 admin interface of the Mothership component.
- * It controls the visibility and population of the "Account" dropdown based on the selected "Client".
- *
- * Behavior Overview:
- * ------------------
- * - On initial page load:
- *   - If no client is selected (value is ''), the Account field (.account_id_wrapper) is hidden.
- *   - The loading spinner (.account-loading-spinner) is also hidden.
- *
- * - When a client is selected:
- *   1. The Account field slides open over 200ms.
- *   2. A loading spinner fades in over 200ms, centered in the account container.
- *   3. An AJAX request is sent to:
- *      /administrator/index.php?option=com_mothership&task=invoice.getAccountsList&client_id={clientId}
- *   4. While waiting, the Account dropdown is hidden.
- *   5. On AJAX success:
- *      - The Account dropdown is cleared and populated with the returned list.
- *      - Each item is an object with { value, text, disable }.
- *      - The spinner fades out (200ms), and the dropdown fades in (200ms).
- *
- * - If the user selects a blank client:
- *   - The Account section fades out and slides closed over 200ms.
- *   - The spinner is reset and hidden.
- *
- * Expected JSON response format:
- * ------------------------------
- * [
- *   { "value": "", "text": "Please select an Account", "disable": false },
- *   { "value": 1,  "text": "Test Account",             "disable": false }
- * ]
- *
- * Security Considerations:
- * ------------------------
- * - CSRF protection should be implemented via Joomla.getOptions('csrf.token') and validated in PHP.
- * - Server-side must validate user permissions and input (client_id).
- * - The PHP controller should return a proper JsonResponse object.
- *
- * DOM Elements:
- * -------------
- * - #jform_client_id            : Client dropdown
- * - .account_id_wrapper         : Wrapper for the Account dropdown (shown/hidden)
- * - .account-loading-spinner    : Spinner shown during AJAX load
- * - #jform_account_id           : Account dropdown (populated dynamically)
- */
-
-jQuery(document).ready(function ($) {
     const clientSelect = $('#jform_client_id');
     const accountWrapper = $('.account_id_wrapper');
     const spinner = $('.account-loading-spinner');
@@ -325,9 +322,8 @@ jQuery(document).ready(function ($) {
             revealAccountField(selectedVal);
         }
     });
-});
 
-jQuery(document).ready(function ($) {
+    
     var $clientField = $('#jform_client_id');
     var $rateField = $('#jform_rate');
     var userModifiedRate = false;
@@ -345,8 +341,6 @@ jQuery(document).ready(function ($) {
             return; // Skip if user already changed rate manually
         }
 
-        $rateField.prop('disabled', true);
-
         $.ajax({
             url: 'index.php?option=com_mothership&task=client.getDefaultRate&id=' + clientId + '&format=json',
             dataType: 'json',
@@ -354,11 +348,17 @@ jQuery(document).ready(function ($) {
                 console.log('Success Default rate:', data.default_rate);
                 if (typeof data.default_rate !== 'undefined') {
                     $rateField.val(data.default_rate);
+                    // Also needs to loop through the 
+                    // Loop through the invoice item rates and update them
+                    $('#invoice-items-table tbody tr').each(function () {
+                        const rateInput = $(this).find('input[name$="[rate]"]');
+                        rateInput.val(data.default_rate);
+                        updateSubtotal(this); // Update subtotal for the row
+                    });
                 }
             },
             complete: function () {
-                console.log('Completed fetching default rate.');
-                $rateField.prop('disabled', false);
+
             }
         });
     });

--- a/admin/assets/js/invoice-edit.js
+++ b/admin/assets/js/invoice-edit.js
@@ -326,3 +326,42 @@ jQuery(document).ready(function ($) {
         }
     });
 });
+
+jQuery(document).ready(function ($) {
+    var $clientField = $('#jform_client_id');
+    var $rateField = $('#jform_rate');
+    var userModifiedRate = false;
+
+    // Track user changes to the rate field
+    $rateField.on('input', function () {
+        userModifiedRate = true;
+    });
+
+    // Watch for client changes
+    $clientField.on('change', function () {
+        var clientId = $(this).val();
+
+        if (!clientId || userModifiedRate) {
+            return; // Skip if user already changed rate manually
+        }
+
+        $rateField.prop('disabled', true);
+
+        $.ajax({
+            url: 'index.php?option=com_mothership&task=client.getDefaultRate&id=' + clientId + '&format=json',
+            dataType: 'json',
+            success: function (data) {
+                console.log('Success Default rate:', data.default_rate);
+                if (typeof data.default_rate !== 'undefined') {
+                    $rateField.val(data.default_rate);
+                }
+            },
+            complete: function () {
+                console.log('Completed fetching default rate.');
+                $rateField.prop('disabled', false);
+            }
+        });
+    });
+});
+
+

--- a/admin/config.xml
+++ b/admin/config.xml
@@ -63,6 +63,7 @@
 		</field>
 		<field name="company_zip" type="text" default="" readonly="" class="" label="COM_MOTHERSHIP_OPTIONS_COMPANY_ZIP_LABEL" description="" required="true" />
 		<field name="company_phone" type="text" default="" readonly="" class="" label="COM_MOTHERSHIP_OPTIONS_COMPANY_PHONE_LABEL" description="" required="true" />
+		<field name="company_default_rate" type="number" default="" class="" label="COM_MOTHERSHIP_OPTIONS_COMPANY_DEFAULT_RATE_LABEL" description="COM_MOTHERSHIP_OPTIONS_COMPANY_DEFAULT_RATE_DESC" required="true" />
 	</fieldset>
 
 	<fieldset name="permissions" label="JCONFIG_PERMISSIONS_LABEL" description="JCONFIG_PERMISSIONS_DESC">

--- a/admin/src/Controller/ClientController.php
+++ b/admin/src/Controller/ClientController.php
@@ -6,6 +6,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use TrevorBice\Component\Mothership\Administrator\Helper\ClientHelper;
 use TrevorBice\Component\Mothership\Administrator\Helper\MothershipHelper;
 
 \defined('_JEXEC') or die;
@@ -85,5 +86,38 @@ class ClientController extends FormController
         }
 
         $this->setRedirect(MothershipHelper::getReturnRedirect(Route::_('index.php?option=com_mothership&view=clients', false)));
+    }
+
+    public function getDefaultRate()
+    {
+        $app = Factory::getApplication();
+        $id = $app->input->getInt('id');
+        
+        $defaultCompanyRate = MothershipHelper::getMothershipOptions('company_default_rate');
+        
+        try 
+        {
+            $client = ClientHelper::getClient($id);
+            $defaultRate = isset($client->default_rate) && $client->default_rate !== '' ? $client->default_rate : $defaultCompanyRate;
+        } catch (\Exception $e) {
+            echo json_encode([
+                'error' => $e->getMessage(),
+            ]);
+            $app->setHeader('status', '400', true);
+            $app->close();
+        }
+
+        $response = json_encode([
+            'default_rate' => $defaultRate,
+            'company_default_rate' => $defaultCompanyRate,
+        ]);
+        
+        echo $response;
+        
+        // $app->setHeader('status', '200', true);
+    
+        $app->setHeader('Content-Type', 'application/json', true);
+       // $app->setBody($response);
+        $app->close();
     }
 }

--- a/admin/src/Helper/ClientHelper.php
+++ b/admin/src/Helper/ClientHelper.php
@@ -74,8 +74,7 @@ class ClientHelper extends ContentHelper
 
         $query = $db->getQuery(true)
             ->select($db->quoteName([
-                'id', 
-                'name'
+                '*'
             ]))
             ->from($db->quoteName('#__mothership_clients'))
             ->where($db->quoteName('id') . ' = ' . $db->quote($client_id));

--- a/admin/src/Helper/ClientHelper.php
+++ b/admin/src/Helper/ClientHelper.php
@@ -67,6 +67,9 @@ class ClientHelper extends ContentHelper
 
     public static function getClient($client_id)
     {
+        if (empty($client_id)) {
+            throw new \InvalidArgumentException("Client ID cannot be null or empty.");
+        }
         $db = Factory::getContainer()->get(\Joomla\Database\DatabaseInterface::class);
 
         $query = $db->getQuery(true)

--- a/admin/src/Helper/MothershipHelper.php
+++ b/admin/src/Helper/MothershipHelper.php
@@ -57,5 +57,30 @@ class MothershipHelper extends ContentHelper
 
         return $default;
     }
+
+    public static function getMothershipOptions($option_name = null)
+    {
+        $params = ComponentHelper::getParams('com_mothership');
+        $options = [];
+            
+        $options['company_name'] = $params->get('company_name', '');
+        $options['company_email'] = $params->get('company_email', '');
+        $options['company_address_1'] = $params->get('company_address_1', '');
+        $options['company_address_2'] = $params->get('company_address_2', '');
+        $options['company_city'] = $params->get('company_city', '');
+        $options['company_state'] = $params->get('company_state', '');
+        $options['company_zip'] = $params->get('company_zip', '');
+        $options['company_phone'] = $params->get('company_phone', '');
+        $options['company_default_rate'] = $params->get('company_default_rate', '');
+
+        if($option_name == null) {
+            return $options;
+        }
+        if (array_key_exists($option_name, $options)) {
+            return $options[$option_name];
+        }
+
+        return $options;
+    }
     
 }

--- a/admin/src/Model/InvoiceModel.php
+++ b/admin/src/Model/InvoiceModel.php
@@ -8,6 +8,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Versioning\VersionableModelTrait;
 use Joomla\CMS\Log\Log;
 use Joomla\Registry\Registry;
+use Joomla\CMS\Component\ComponentHelper;
 
 \defined('_JEXEC') or die;
 
@@ -77,16 +78,25 @@ class InvoiceModel extends AdminModel
 
     protected function loadFormData()
     {
-        $data = Factory::getApplication()->getUserState('com_mothership.edit.invoice.data', []);
+        $app = Factory::getApplication();
+        $data = $app->getUserState('com_mothership.edit.invoice.data', []);
 
-        if (empty($data)) {
+        if ((is_object($data) && isset($data->id) && empty($data->id)) || (is_array($data) && empty($data['id']))) {
             $data = $this->getItem();
+
+            if (empty($data->id)) {
+                $params = ComponentHelper::getParams('com_mothership');
+                $defaultRate = $params->get('company_default_rate');
+                if ($defaultRate !== null) {
+                    $data->rate = $defaultRate;
+                }
+            }
         }
 
         $this->preprocessData('com_mothership.invoice', $data);
-
         return $data;
     }
+
 
     public function getItem($pk = null)
     {

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -128,7 +128,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                         <?php if (count($payment_ids) > 0): ?>
                                         <ul style="margin-bottom:0px;">
                                             <?php foreach ($payment_ids as $paymentId): ?>
-                                                <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=payment&layout=edit&id=<?php echo $paymentId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=invoices')); ?>"><?php echo "Payment #" . str_pad($paymentId, 2, "0", STR_PAD_LEFT); ?></a></small></li>
+                                                <li style="list-style: none;"><small><a href="index.php?option=com_mothership&view=payment&layout=edit&id=<?php echo $paymentId; ?>&return=<?php echo base64_encode(Route::_('index.php?option=com_mothership&view=invoices')); ?>"><?php echo "Payment #{$paymentId}"; ?></a></small></li>
                                             <?php endforeach; ?>
                                         </ul>
                                         <?php endif; ?>


### PR DESCRIPTION
# Summary
Makes it so that new invoices default first to the Client Rate and then to the Company Default Rate.  This allows a business to set their default rate, buts till override it on a Client by Client basis.

## Changes
- Fixes #66 
- Adds method `getMothershipOptions($option_name)` to the MothershipHelper class to get the mothership options
- Changes ClientHelper method `getclient` to throw errors if empty or null values are passed.
- Fixes a bug with the Front End View Invoices page that was displaying the wrong text for the Payment Id 