### PR TITLE
Bugfix: Clicking to sort by `id` does nothing.

### DIFF
--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -71,10 +71,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                 </th>
 
                                 <th scope="col" class="w-10">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_DUE', 'i.due', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_DUE', 'i.due_date', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="w-10">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_CREATED', 'a.created', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_CREATED', 'i.created', $listDirn, $listOrder); ?>
                                 </th>
                             </tr>
                         </thead>

--- a/admin/tmpl/invoices/default.php
+++ b/admin/tmpl/invoices/default.php
@@ -42,7 +42,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     <?php echo HTMLHelper::_('grid.checkall'); ?>
                                 </th>
                                 <th scope="col" class="w-3 d-none d-lg-table-cell">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'i.id', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="w-10">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_MOTHERSHIP_INVOICE_HEADING_NUMBER', 'i.number', $listDirn, $listOrder); ?>


### PR DESCRIPTION
# Summary
Fixes minor issue with the sorting on the view all invoices page.

## Changes
- Fixes #69 
- Also fixes sorting for `i.due_date` which was incorrectly set to `i.due`
- Fixes sorting for `i.created` which was incorrectly set to `a.created`