### PR TITLE
Add thank you page

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ This payment method allows clients to pay invoices using PayPal. Once the paymen
 ### Zelle
 This payment method is essentially a digital version of "Pay by Check". Once the payment has been confirmed, an administrator will need to manually update the status of the payment to confirmed.
 
+### Pay By Check
+This payment method allows clients to pay invoices by mailing a physical check. Once the check is received and processed, an administrator will need to manually update the status of the payment to confirmed. This method is ideal for clients who prefer traditional payment methods or do not use digital payment platforms.
+
 ---
 
 # Helpers

--- a/README.md
+++ b/README.md
@@ -331,15 +331,10 @@ To create a Mothership Payment plugin, follow these steps:
 
     class PlgMothershipPaymentsmypaymentmethod extends MothershipPaymentsPlugin
     {
-         public function onMothershipPaymentRequest($paymentData)
-         {
-              // Implement your payment processing logic here
+         public function initiate($payment, $invoice) {
+          /* Initiates the payment process for this plugin whatever that is */
          }
-
-         public function onAfterInitialiseMothership()
-         {
-              // Any initialization code for your plugin
-         }
+         
     }
     ```
 
@@ -354,6 +349,9 @@ To create a Mothership Payment plugin, follow these steps:
          <files>
               <filename plugin="mypaymentmethod">mypaymentmethod.php</filename>
          </files>
+         <fieldset name="basic">
+              <field name="display_name" type="text" label="Display Name" description="Description here" default="mypaymentmethod" />
+          </fieldset>
     </extension>
     ```
 

--- a/admin/mothership.xml
+++ b/admin/mothership.xml
@@ -7,7 +7,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <authorEmail>trevorbicewebdesign@gmail.com</authorEmail>
     <authorUrl>https://webdesign.trevorbice.com</authorUrl>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <description>COM_MOTHERSHIP_XML_DESCRIPTION</description>
     <namespace path="src">TrevorBice\Component\Mothership</namespace>
     <install>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "trevorbicewebdesign/mothership",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Mothership is a Joomla extension designed specifically for web development agencies to manage invoicing, quoting, help tickets, timelogging, expenses, taxes, and logging.",
   "type": "joomla-extension",
   "license": "GPL-2.0-or-later",

--- a/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.ini
+++ b/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.ini
@@ -3,3 +3,5 @@ COM_MOTHERSHIP_PAYBYCHECK_PLUGIN="Mothership Payment - Pay by Check"
 
 COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_LABEL="Payment Display Label"
 COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_DESC="The name of the payment method as displayed to customers during checkout."
+COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_LABEL="Payment Instructions"
+COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_DESC="Instructions for the customer on how to pay by check. This will be displayed on the checkout page."

--- a/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.ini
+++ b/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.ini
@@ -1,0 +1,5 @@
+; en-GB.plg_mothership-payment_paybycheck.ini
+COM_MOTHERSHIP_PAYBYCHECK_PLUGIN="Mothership Payment - Pay by Check"
+
+COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_LABEL="Payment Display Label"
+COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_DESC="The name of the payment method as displayed to customers during checkout."

--- a/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.sys.ini
+++ b/plugins/mothership-payment/paybycheck/language/en-GB.plg_mothership-payment_paybycheck.sys.ini
@@ -1,0 +1,3 @@
+; en-GB.plg_mothership-payment_paybycheck.sys.ini
+; System language file for the Mothership Pay by Check Payment Plugin
+COM_MOTHERSHIP_PAYBYCHECK_PLUGIN="Mothership Payment - Pay By Check"

--- a/plugins/mothership-payment/paybycheck/paybycheck.php
+++ b/plugins/mothership-payment/paybycheck/paybycheck.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @package     Mothership
+ * @subpackage  Plugin.Mothership-Payment.PayPal
+ * @copyright   (C) 2025 Trevor Bice
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Layout\FileLayout;
+use Joomla\Database\DatabaseDriver;
+use TrevorBice\Component\Mothership\Administrator\Helper\PaymentHelper;
+use TrevorBice\Component\Mothership\Administrator\Helper\InvoiceHelper;
+
+class PlgMothershipPaymentZelle extends CMSPlugin
+{
+    protected $autoloadLanguage = true;
+
+    /**
+     * Intercept request after routing. If "paybycheckinstructions=1", display our custom HTML.
+     */
+    public function onAfterRoute()
+    {
+        $app     = Factory::getApplication();
+        $option  = $app->input->getCmd('option');
+        $isZelle = $app->input->getCmd('paybycheckinstructions', '0');
+
+        // Only act on front-end requests to com_mothership with &paybycheckinstructions=1
+        if ($app->isClient('site') && $option === 'com_mothership' && $isZelle === '1')
+        {
+            // Gather data as needed
+            $invoiceId = $app->input->getInt('invoice_id', 0);
+
+            // Use Joomla's FileLayout to load the layout from /tmpl/paybycheckinstructions.php
+            $layoutPath = __DIR__ . '/tmpl'; // plugin folder/tmpl
+            $layout     = new FileLayout('paybycheckinstructions', $layoutPath);
+
+            // Render the layout, passing data in an array
+            $html = $layout->render(['invoiceId' => $invoiceId]);
+
+            // Output the HTML
+            echo $html;
+
+            // End the request so Joomla doesn't continue
+            $app->close();
+        }
+    }
+
+    /**
+     * Calculate the processing fee based on the payment amount.
+     *
+     * @param   float  $amount  The payment amount.
+     *
+     * @return  string  The calculated fee formatted to two decimals.
+     */
+    public function getFee($amount)
+    {
+        $base_fee = 0.30;
+        $percentage_fee = 3.9;
+        $fee_total = $base_fee + ($amount * ($percentage_fee / 100));
+        return number_format($fee_total, 2, '.', '');
+    }
+
+    /**
+     * Return a human-readable string displaying the fee structure and the calculated fee.
+     *
+     * @param   float  $amount  The payment amount.
+     *
+     * @return  string  A formatted message showing the fee breakdown and the total fee.
+     */
+    public function displayFee($amount)
+    {
+        $calculatedFee = $this->getFee($amount);
+        return "Fee: 3.9% + \$0.30 = \$" . $calculatedFee;
+    }
+
+    /**
+     * Handle payment requests from Mothership.
+     *
+     * @param   object  $invoice      The invoice object (from Mothership)
+     * @param   array   $paymentData  Any relevant payment data
+     *
+     * @return  array|null  Result of the payment process or null if not handled
+     */
+    public function onMothershipPaymentRequest($invoice, $paymentData)
+    {
+        // Only handle if this is the selected payment method
+        if ($invoice->payment_method !== 'paybycheck') {
+            return null;
+        }
+
+        $paymentLink = "https://joomlav4.trevorbice.com/?option=com_mothership&view=&invoices";
+
+        InvoiceHelper::updateInvoiceStatus($invoice->id, 1);
+
+        PaymentHelper::insertPaymentRecord(
+            $invoice->client_id,
+            $invoice->account_id,
+            $invoice->total,
+            date("Y-m-d H:i:s"),
+            0,
+            false,
+            'PayPal',
+            0,
+            2,
+        );
+
+        return [
+            'status'  => 'redirect',
+            'url'     => $paymentLink,
+        ];
+    }
+
+}

--- a/plugins/mothership-payment/paybycheck/paybycheck.xml
+++ b/plugins/mothership-payment/paybycheck/paybycheck.xml
@@ -11,6 +11,7 @@
         <fields name="params">
             <fieldset name="basic">
                 <field name="display_name" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_DESC" default="Zelle" />
+                <field name="checkpayee" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_PAYEE_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_PAYEE_DESC" default="Your Company Name" />
                 <field name="instructions" type="textarea" label="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_DESC" />
             </fieldset>
         </fields>

--- a/plugins/mothership-payment/paybycheck/paybycheck.xml
+++ b/plugins/mothership-payment/paybycheck/paybycheck.xml
@@ -1,0 +1,19 @@
+<extension type="plugin" group="mothership-payment" version="0.0.5" method="paybycheck" element="paybycheck">
+    <name>COM_MOTHERSHIP_PAYBYCHECK_PLUGIN</name>
+    <files>
+        <filename plugin="paybycheck">paybycheck.php</filename>
+    </files>
+    <languages>
+        <language tag="en-GB">en-GB.plg_mothership-payment_paybycheck.ini</language>
+        <language tag="en-GB">en-GB.plg_mothership-payment_paybycheck.sys.ini</language>
+    </languages>
+    <config>
+        <fields name="params">
+            <fieldset name="basic">
+                <field name="display_name" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_DESC" default="Zelle" />
+                <field name="paybycheck_email_phone" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_EMAIL_PHONE_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_EMAIL_PHONE_DESC" required="true" />
+                <field name="instructions" type="textarea" label="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_DESC" />
+            </fieldset>
+        </fields>
+    </config>
+</extension>

--- a/plugins/mothership-payment/paybycheck/paybycheck.xml
+++ b/plugins/mothership-payment/paybycheck/paybycheck.xml
@@ -11,7 +11,6 @@
         <fields name="params">
             <fieldset name="basic">
                 <field name="display_name" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_DISPLAY_NAME_DESC" default="Zelle" />
-                <field name="paybycheck_email_phone" type="text" label="COM_MOTHERSHIP_PAYBYCHECK_EMAIL_PHONE_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_EMAIL_PHONE_DESC" required="true" />
                 <field name="instructions" type="textarea" label="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_LABEL" description="COM_MOTHERSHIP_PAYBYCHECK_INSTRUCTIONS_DESC" />
             </fieldset>
         </fields>

--- a/plugins/mothership-payment/paybycheck/tmpl/instructions.php
+++ b/plugins/mothership-payment/paybycheck/tmpl/instructions.php
@@ -6,8 +6,14 @@
  * @license     ...
  */
 
+
 // Protect against direct access
 defined('_JEXEC') or die;
+
+// get the plugin settings
+$plugin = JPluginHelper::getPlugin('mothership-payment', 'paybycheck');
+$pluginParams = new JRegistry($plugin->params);
+
 
 /** @var array $displayData */
 $invoiceId = $displayData['invoiceId'] ?? 0;
@@ -15,8 +21,9 @@ $invoiceId = $displayData['invoiceId'] ?? 0;
 <h1>Pay By Check Payment Instructions</h1>
 <p>Invoice ID: <?php echo (int) $invoiceId; ?></p>
 <p>
-  Please send payment via Zelle to <strong>payments@example.com</strong>.
+  Please write a check to <strong><?= $pluginParams['checkpayee']; ?></strong>.
 </p>
 <p>
-  After sending the payment, return to the site to confirm.
-</p>
+  After sending the payment please visit <a href="<?php echo JRoute::_('index.php?option=com_mothership&view=payments'); ?>">Payments</a><br/>
+  Your payment will have been set to `pending` until an administrator receives payment and can set the payment to `completed`.<br/>
+  <button type="button" onclick="alert('Payment Sent')">Payment Sent</button>

--- a/plugins/mothership-payment/paybycheck/tmpl/instructions.php
+++ b/plugins/mothership-payment/paybycheck/tmpl/instructions.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package     Mothership
+ * @subpackage  Plugin.Mothership-Payment.Zelle
+ * @copyright   ...
+ * @license     ...
+ */
+
+// Protect against direct access
+defined('_JEXEC') or die;
+
+/** @var array $displayData */
+$invoiceId = $displayData['invoiceId'] ?? 0;
+?>
+<h1>Pay By Check Payment Instructions</h1>
+<p>Invoice ID: <?php echo (int) $invoiceId; ?></p>
+<p>
+  Please send payment via Zelle to <strong>payments@example.com</strong>.
+</p>
+<p>
+  After sending the payment, return to the site to confirm.
+</p>

--- a/plugins/mothership-payment/paypal/paypal.php
+++ b/plugins/mothership-payment/paypal/paypal.php
@@ -140,7 +140,7 @@ class PlgMothershipPaymentPaypal extends CMSPlugin
             'no_shipping' => 1,
             'cancel_return' => "{$domain}index.php?option=com_mothership&view=invoices",
             'notify_url' => "{$domain}index.php?option=com_mothership&paypal_notify=1&invoice={$invoice_id}",
-            'return' => "{$domain}index.php?option=com_mothership&view=invoices",
+            'return' => "{$domain}index.php?option=com_mothership&view=payments&task=thankyou&invoice_id={$invoice_id}",
         ];
 
         return $paypalUrl . http_build_query($paypalData);

--- a/plugins/mothership-payment/zelle/tmpl/instructions.php
+++ b/plugins/mothership-payment/zelle/tmpl/instructions.php
@@ -9,14 +9,20 @@
 // Protect against direct access
 defined('_JEXEC') or die;
 
+// get the plugin settings
+$plugin = JPluginHelper::getPlugin('mothership-payment', 'zelle');
+$pluginParams = new JRegistry($plugin->params);
+
 /** @var array $displayData */
 $invoiceId = $displayData['invoiceId'] ?? 0;
 ?>
 <h1>Zelle Payment Instructions</h1>
 <p>Invoice ID: <?php echo (int) $invoiceId; ?></p>
 <p>
-  Please send payment via Zelle to <strong>payments@example.com</strong>.
+  Please send payment via Zelle to <strong><?php echo $pluginParams['zelle_email']; ?></strong>.
 </p>
 <p>
-  After sending the payment, return to the site to confirm.
+  After sending the payment please visit <a href="<?php echo JRoute::_('index.php?option=com_mothership&view=payments'); ?>">Payments</a><br/>
+  Your payment will have been set to `pending` until an administrator receives payment and can set the payment to `completed`.<br/>
+  <button type="button" onclick="alert('Payment Sent')">Payment Sent</button>
 </p>

--- a/plugins/mothership-payment/zelle/zelle.php
+++ b/plugins/mothership-payment/zelle/zelle.php
@@ -21,35 +21,6 @@ class PlgMothershipPaymentZelle extends CMSPlugin
 {
     protected $autoloadLanguage = true;
 
-    /**
-     * Intercept request after routing. If "zelleinstructions=1", display our custom HTML.
-     */
-    public function onAfterRoute()
-    {
-        $app     = Factory::getApplication();
-        $option  = $app->input->getCmd('option');
-        $isZelle = $app->input->getCmd('zelleinstructions', '0');
-
-        // Only act on front-end requests to com_mothership with &zelleinstructions=1
-        if ($app->isClient('site') && $option === 'com_mothership' && $isZelle === '1')
-        {
-            // Gather data as needed
-            $invoiceId = $app->input->getInt('invoice_id', 0);
-
-            // Use Joomla's FileLayout to load the layout from /tmpl/zelleinstructions.php
-            $layoutPath = __DIR__ . '/tmpl'; // plugin folder/tmpl
-            $layout     = new FileLayout('zelleinstructions', $layoutPath);
-
-            // Render the layout, passing data in an array
-            $html = $layout->render(['invoiceId' => $invoiceId]);
-
-            // Output the HTML
-            echo $html;
-
-            // End the request so Joomla doesn't continue
-            $app->close();
-        }
-    }
 
     /**
      * Calculate the processing fee based on the payment amount.
@@ -79,41 +50,46 @@ class PlgMothershipPaymentZelle extends CMSPlugin
         return "Fee: 3.9% + \$0.30 = \$" . $calculatedFee;
     }
 
-    /**
-     * Handle payment requests from Mothership.
-     *
-     * @param   object  $invoice      The invoice object (from Mothership)
-     * @param   array   $paymentData  Any relevant payment data
-     *
-     * @return  array|null  Result of the payment process or null if not handled
-     */
-    public function onMothershipPaymentRequest($invoice, $paymentData)
+    public function initiate($payment, $invoice)
     {
-        // Only handle if this is the selected payment method
-        if ($invoice->payment_method !== 'zelle') {
-            return null;
+        $app = Factory::getApplication();
+        $input = $app->getInput();
+        $invoiceId = $input->getInt('id', 0);
+        // $amount = $input->getFloat('amount', 0.0); // Retrieve the amount from the input
+        // echo 'index.php?option=com_mothership&view=payment&task=zelle.displayInstructions&invoice_id=' . $invoiceId . '&amount=' . $amount;
+        // die();
+
+        if ($invoiceId) {
+            // Redirect to the Zelle instructions page with the invoice ID and amount
+            $paymentLink = Route::_("index.php?option=com_mothership&controller=payment&task=pluginTask&plugin=zelle&action=displayInstructions&invoice_id={$invoiceId}", false);
+            Factory::getApplication()->redirect($paymentLink);
+        } else {
+            // Handle error: invalid invoice ID or amount
+            // Log::add('Invalid invoice ID or amount for Zelle payment.', 'error', 'jerror');
+            return false;
         }
+    }
 
-        $paymentLink = "https://joomlav4.trevorbice.com/?option=com_mothership&view=&invoices";
+    public function displayInstructions()
+    {
+        // Load the Joomla application and input objects
+        $app = Factory::getApplication();
+        $input = $app->getInput();
+        $invoiceId = $input->getInt('invoice_id', 0);
+        $amount = $input->getFloat('amount', 0.0);
 
-        InvoiceHelper::updateInvoiceStatus($invoice->id, 1);
+        if ($invoiceId) {
+            // Load the Zelle instructions layout
+            $layoutPath = __DIR__ . '/tmpl'; // plugin folder/tmpl
+            $layout = new FileLayout('instructions', $layoutPath);
 
-        PaymentHelper::insertPaymentRecord(
-            $invoice->client_id,
-            $invoice->account_id,
-            $invoice->total,
-            date("Y-m-d H:i:s"),
-            0,
-            false,
-            'PayPal',
-            0,
-            2,
-        );
-
-        return [
-            'status'  => 'redirect',
-            'url'     => $paymentLink,
-        ];
+            // Render the layout, passing data in an array
+            echo $layout->render(['invoiceId' => $invoiceId, 'amount' => $amount]);
+        } else {
+            // Handle error: invalid invoice ID or amount
+            // Log::add('Invalid invoice ID or amount for Zelle payment.', 'error', 'jerror');
+            return false;
+        }
     }
 
 }

--- a/plugins/mothership-payment/zelle/zelle.xml
+++ b/plugins/mothership-payment/zelle/zelle.xml
@@ -11,7 +11,8 @@
         <fields name="params">
             <fieldset name="basic">
                 <field name="display_name" type="text" label="COM_MOTHERSHIP_ZELLE_DISPLAY_NAME_LABEL" description="COM_MOTHERSHIP_ZELLE_DISPLAY_NAME_DESC" default="Zelle" />
-                <field name="zelle_email_phone" type="text" label="COM_MOTHERSHIP_ZELLE_EMAIL_PHONE_LABEL" description="COM_MOTHERSHIP_ZELLE_EMAIL_PHONE_DESC" required="true" />
+                <field name="zelle_email" type="email" label="COM_MOTHERSHIP_ZELLE_EMAIL_LABEL" description="COM_MOTHERSHIP_ZELLE_EMAIL_DESC" required="true" />
+                <field name="zelle_phone" type="phone" label="COM_MOTHERSHIP_ZELLE_PHONE_LABEL" description="COM_MOTHERSHIP_ZELLE_PHONE_DESC" required="true" />
                 <field name="instructions" type="textarea" label="COM_MOTHERSHIP_ZELLE_INSTRUCTIONS_LABEL" description="COM_MOTHERSHIP_ZELLE_INSTRUCTIONS_DESC" />
             </fieldset>
         </fields>

--- a/site/src/Controller/PaymentController.php
+++ b/site/src/Controller/PaymentController.php
@@ -18,16 +18,58 @@ PluginHelper::importPlugin('mothership-payment');
 
 class PaymentController extends BaseController
 {
+    public function __construct($config = [])
+    {
+        parent::__construct($config);
+        $this->registerTask('zelle.displayInstructions', 'zelleDisplayInstructions');
+    }
+
+    public function zelleDisplayInstructions()
+    {
+        // Add the logic for displaying Zelle instructions here
+        $app = Factory::getApplication();
+        $app->enqueueMessage('Zelle instructions displayed successfully.', 'message');
+    }
+    
     public function display($cachable = false, $urlparams = [])
     {
         $this->input->set('view', $this->input->getCmd('view', 'payment'));
         parent::display($cachable, $urlparams);
+    }
+    
+    public function pluginTask()
+    {
+        $app = Factory::getApplication();
+        $input = $app->getInput();
+    
+        $pluginName = $input->getCmd('plugin');
+        $action     = $input->getCmd('action');
+    
+        if (!$pluginName || !$action) {
+            throw new \RuntimeException('Missing plugin or action.');
+        }
+    
+        try {
+            $plugin = $this->getPluginInstance($pluginName);
+    
+            if (!method_exists($plugin, $action)) {
+                throw new \RuntimeException("Plugin method '$action' not found in '$pluginName'");
+            }
+    
+            return $plugin->$action();
+        } catch (\Exception $e) {
+            $app->enqueueMessage("Plugin error: " . $e->getMessage(), 'error');
+            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return;
+        }
     }
 
     public function thankyou()
     {
         $app = Factory::getApplication();
         $input = $app->getInput();
+
+        /*
         $id = $input->getInt('id');
 
         if (!$id) {
@@ -35,62 +77,21 @@ class PaymentController extends BaseController
             $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
             return;
         }
+        */
 
-        $model = $this->getModel('Payment');
-        $payment = $model->getItem($id);
+        // $model = $this->getModel('Payment');
+        // $payment = $model->getItem($id);
 
+        /*
         if (!$payment) {
             $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_PAYMENT_NOT_FOUND'), 'error');
             $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
             return;
         }
+            */
 
-        // Correct way to pass data to the view:
-        $view = $this->getView('Payment', 'html');
-        $view->setModel($model, true);
-        $view->item = $payment;
-        $view->setLayout('thank-you');
-        $view->display();
-    }
-
-    public function downloadPdf()
-    {
-        $app = Factory::getApplication();
-        $input = $app->getInput();
-        $id = $input->getInt('id');
-
-        if (!$id) {
-            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_ID'), 'error');
-            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
-            return;
-        }
-
-        $model = $this->getModel('Payment');
-        $payment = $model->getItem($id);
-
-        if (!$payment) {
-            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_PAYMENT_NOT_FOUND'), 'error');
-            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
-            return;
-        }
-
-        // Generate the HTML
-        $layout = new FileLayout('pdf', JPATH_ROOT . '/components/com_mothership/layouts');
-        $html = $layout->render(['payment' => $payment]);
-
-        // Turn off Joomla's output
-        ob_end_clean();
-        header('Content-Type: application/pdf');
-        header('Content-Disposition: inline; filename="Payment-' . $payment->number . '.pdf"');
-        header('Cache-Control: private, max-age=0, must-revalidate');
-        header('Pragma: public');
-
-        // Generate and output the PDF
-        $pdf = new Mpdf();
-        $pdf->WriteHTML($html);
-        $pdf->Output(null, 'I');
-
-        $app->close();
+        // Redirect to the thank you page layout with the correct payment id and invoice id
+        $this->setRedirect(Route::_('index.php?option=com_mothership&view=payment&layout=thank-you&id=1&invoice_id=1', false));
     }
 
     public function payment()
@@ -139,6 +140,34 @@ class PaymentController extends BaseController
         $view->display();
     }
 
+    protected function getPluginInstance(string $pluginName)
+    {
+        // Normalize plugin name casing
+        $normalized = strtolower($pluginName);
+
+        // Load the plugin group
+        PluginHelper::importPlugin('mothership-payment');
+
+        $plugins = PluginHelper::getPlugin('mothership-payment');
+
+        foreach ($plugins as $plugin) {
+            if ($plugin->name === $normalized) {
+                // Build expected class name, e.g., PlgMothershippaymentPaypal
+                $className = 'PlgMothershipPayment' . ucfirst($plugin->name);
+       
+                if (!class_exists($className)) {
+                    throw new \RuntimeException("Plugin class '$className' not found.");
+                }
+
+                // Instantiate and return
+                $dispatcher = Factory::getApplication()->getDispatcher();
+                return new $className($dispatcher, (array) $plugin);
+            }
+        }
+
+        throw new \RuntimeException("Payment plugin '$pluginName' not found or not enabled. 1 ".json_encode($plugins));
+    }
+
     public function processPayment()
     {
         $app = Factory::getApplication();
@@ -161,34 +190,26 @@ class PaymentController extends BaseController
             return;
         }
 
-        // Set the payment method
+
+        // Save the selected payment method
         $payment->payment_method = $paymentMethod;
+        $payment->store(); // Persist it now
 
-        $paymentData = [
-            'payment_method' => $paymentMethod,
-        ];
+        // Direct plugin invocation
+        try {
+            $plugin = $this->getPluginInstance($paymentMethod);
 
-        // Import the payment plugins BEFORE dispatching the event
-        \Joomla\CMS\Plugin\PluginHelper::importPlugin('mothership-payment');
-
-        $dispatcher = Factory::getApplication()->getDispatcher();
-        $event = new Event('onMothershipPaymentRequest', ['payment' => $payment, 'paymentData' => $paymentData]);
-        
-        $results = $dispatcher->dispatch('onMothershipPaymentRequest', $event);
-
-        if (!empty($results)) {
-    
-            $arguments = $event->getArguments();
-            foreach ($arguments['result'] as $result) {
-                if ($result['status'] === 'redirect') {
-                    $this->setRedirect($result['url']);
-                    return;
-                }
+            if (!method_exists($plugin, 'process')) {
+                throw new \RuntimeException("Plugin '$paymentMethod' does not support processing. 1",json_encode($plugin));
             }
-        }
 
-        $app->enqueueMessage(Text::_(sprintf('COM_MOTHERSHIP_NO_PAYMENT_HANDLER', $paymentMethod)), 'danger');
-        $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return $plugin->process($payment); // Let the plugin redirect or render
+        } catch (\Exception $e) {
+            $app->enqueueMessage(Text::sprintf('COM_MOTHERSHIP_PAYMENT_PROCESSING_FAILED', $e->getMessage()), 'error');
+            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return;
+        }
     }
+
 
 }

--- a/site/src/Controller/PaymentController.php
+++ b/site/src/Controller/PaymentController.php
@@ -24,6 +24,35 @@ class PaymentController extends BaseController
         parent::display($cachable, $urlparams);
     }
 
+    public function thankyou()
+    {
+        $app = Factory::getApplication();
+        $input = $app->getInput();
+        $id = $input->getInt('id');
+
+        if (!$id) {
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_ID'), 'error');
+            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return;
+        }
+
+        $model = $this->getModel('Payment');
+        $payment = $model->getItem($id);
+
+        if (!$payment) {
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_PAYMENT_NOT_FOUND'), 'error');
+            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return;
+        }
+
+        // Correct way to pass data to the view:
+        $view = $this->getView('Payment', 'html');
+        $view->setModel($model, true);
+        $view->item = $payment;
+        $view->setLayout('thank-you');
+        $view->display();
+    }
+
     public function downloadPdf()
     {
         $app = Factory::getApplication();

--- a/site/src/Model/InvoicesModel.php
+++ b/site/src/Model/InvoicesModel.php
@@ -9,23 +9,23 @@ class InvoicesModel extends ListModel
 {
     public function getItems()
     {
-        $user = Factory::getUser();
+        $user = \Joomla\CMS\Factory::getUser();
         $userId = $user->id;
-        $clientId = MothershipHelper::getUserClientId($userId);
+        $clientId = \TrevorBice\Component\Mothership\Site\Helper\MothershipHelper::getUserClientId($userId);
 
         if (!$clientId) {
-            // display a warning to the user
-            $app = Factory::getApplication();
+            $app = \Joomla\CMS\Factory::getApplication();
             $app->enqueueMessage("You do not have an associated client.", 'danger');
-            return;
+            return [];
         }
 
         $db = $this->getDbo();
         $query = $db->getQuery(true);
+
         $query->select([
             'i.*',
             'a.name AS account_name',
-    
+
             // Lifecycle status
             'CASE ' . $db->quoteName('i.status') .
                 ' WHEN 1 THEN ' . $db->quote('Draft') .
@@ -33,39 +33,50 @@ class InvoicesModel extends ListModel
                 ' WHEN 3 THEN ' . $db->quote('Cancelled') .
                 ' WHEN 4 THEN ' . $db->quote('Closed') .
                 ' ELSE ' . $db->quote('Unknown') . ' END AS status',
-    
-            // Payment data
+
+            // Payment summary
             'COALESCE(pay.total_paid, 0) AS total_paid',
             'pay.payment_ids',
-            'CASE' .
-                ' WHEN COALESCE(pay.total_paid, 0) <= 0 THEN ' . $db->quote('Unpaid') .
-                ' WHEN COALESCE(pay.total_paid, 0) < i.total THEN ' . $db->quote('Partially Paid') .
-                ' ELSE ' . $db->quote('Paid') .
-            ' END AS payment_status'
+
+            // Has pending payment
+            '(SELECT COUNT(*) FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip2') . '
+            JOIN ' . $db->quoteName('#__mothership_payments', 'p2') . ' ON ip2.payment_id = p2.id
+            WHERE ip2.invoice_id = i.id AND p2.status = 1) AS has_pending_payment',
+
+            // Payment status
+            'CASE
+                WHEN (SELECT COUNT(*) FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip2') . '
+                    JOIN ' . $db->quoteName('#__mothership_payments', 'p2') . ' ON ip2.payment_id = p2.id
+                    WHERE ip2.invoice_id = i.id AND p2.status = 1) > 0 THEN ' . $db->quote('Pending Confirmation') . '
+                WHEN COALESCE(pay.total_paid, 0) <= 0 THEN ' . $db->quote('Unpaid') . '
+                WHEN COALESCE(pay.total_paid, 0) < i.total THEN ' . $db->quote('Partially Paid') . '
+                ELSE ' . $db->quote('Paid') . '
+            END AS payment_status'
         ]);
-    
+
         $query->from($db->quoteName('#__mothership_invoices', 'i'))
             ->join('LEFT', '#__mothership_accounts AS a ON i.account_id = a.id')
-    
-            // 👇 JOIN payment info like in backend
+
+            // Join payment aggregation
             ->join(
                 'LEFT',
                 '(SELECT ip.invoice_id,
-                         SUM(ip.applied_amount) AS total_paid,
-                         GROUP_CONCAT(p.id ORDER BY p.payment_date) AS payment_ids
-                  FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip') . '
-                  JOIN ' . $db->quoteName('#__mothership_payments', 'p') . ' ON ip.payment_id = p.id
-                  WHERE p.status = 2
-                  GROUP BY ip.invoice_id) AS pay
-                  ON pay.invoice_id = i.id'
+                        SUM(ip.applied_amount) AS total_paid,
+                        GROUP_CONCAT(p.id ORDER BY p.payment_date) AS payment_ids
+                FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip') . '
+                JOIN ' . $db->quoteName('#__mothership_payments', 'p') . ' ON ip.payment_id = p.id
+                WHERE p.status = 2
+                GROUP BY ip.invoice_id) AS pay
+                ON pay.invoice_id = i.id'
             )
-    
+
             ->where($db->quoteName('i.status') . ' != 1')
             ->where($db->quoteName('i.client_id') . ' = :clientId')
             ->bind(':clientId', $clientId, \Joomla\Database\ParameterType::INTEGER);
-    
+
         $db->setQuery($query);
-    
+
         return $db->loadObjectList();
     }
+
 }

--- a/site/src/View/Payment/HtmlView.php
+++ b/site/src/View/Payment/HtmlView.php
@@ -19,6 +19,8 @@ class HtmlView extends BaseHtmlView
             return;
         }
         $this->item = $this->getModel()->getItem();
+        $input = Factory::getApplication()->getInput();
+        $this->invoiceId = $input->getInt('invoice_id');
 
         if (!$this->item) {
             throw new \Exception('Payment not found', 404);

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -51,7 +51,7 @@ use Joomla\CMS\Language\Text;
                     <?php endif; ?>
                 </td>
                 <td>
-                    <?php if($invoice->status === 'Opened' || $invoice->status === 'Late'): ?>
+                    <?php if($invoice->status === 'Opened'): ?>
                     <?php
                     $dueDate = new DateTime($invoice->due_date, new DateTimeZone('UTC'));
                     $dueDate->setTime(23, 59, 59);
@@ -66,7 +66,7 @@ use Joomla\CMS\Language\Text;
                 <td>
                     <ul>
                         <li><a href="<?php echo Route::_('index.php?option=com_mothership&task=invoice.edit&id=' . $invoice->id); ?>">View</a></li>
-                        <?php if($invoice->status === 'Opened' || $invoice->status === 'Late'): ?>
+                        <?php if($invoice->status === 'Opened' && $invoice->payment_status != 'Pending Confirmation'): ?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Pay</a></li>
                         <?php endif; ?>
                     </ul>
@@ -77,15 +77,35 @@ use Joomla\CMS\Language\Text;
         <?php endforeach; ?>
     </tbody>
 </table>
-<div class="card mt-4">
-  <div class="card-header">
-    Invoice Status Legend
-  </div>
-  <div class="card-body">
-    <ul class="mb-0">
-        <li><strong>Opened</strong>: Invoice is awaiting payment.</li>
-        <li><strong>Late</strong>: Invoice is past due.</li>
-        <li><strong>Paid</strong>: Invoice has been paid.</li>
-    </ul>
-  </div>
+<div class="row mt-4">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                Invoice Status Legend
+            </div>
+            <div class="card-body">
+                <ul class="mb-0"></ul>
+                    <li><strong>Opened</strong>: Invoice is awaiting payment.</li>
+                    <li><strong>Cancelled</strong>: Invoice has been voided and is no longer valid.</li>
+                    <li><strong>Closed</strong>: Invoice has been paid and is no longer active.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                Payment Status Legend
+            </div>
+            <div class="card-body">
+                <ul class="mb-0">
+                    <li><strong>Unpaid</strong>: Payment has not been made yet.</li>
+                    <li><strong>Paid</strong>: Payment has been completed in full.</li>
+                    <li><strong>Partially Paid</strong>: A partial payment has been made, but the full amount is still outstanding.</li>
+                    <li><strong>Pending Confirmation</strong>: Payment has been initiated but is awaiting confirmation.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
 </div>
+

--- a/site/tmpl/payment/thank-you.php
+++ b/site/tmpl/payment/thank-you.php
@@ -1,0 +1,20 @@
+<?php
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+?>
+
+<div class="container mt-5">
+    <h1 class="text-success">Thank You</h1>
+    <p>Your payment was successfully received.</p>
+    <?php if (!empty($this->invoiceId)) : ?>
+        <p>Invoice #<?php echo (int) $this->invoiceId; ?></p>
+        <p>Payment Status: pending</p>
+    <?php endif; ?>
+
+    <div class="mt-4">
+        <a href="<?php echo Route::_('index.php?option=com_mothership&view=payments'); ?>" class="btn btn-primary">
+            Return to Payments
+        </a>
+    </div>
+</div>

--- a/site/tmpl/payments/default.php
+++ b/site/tmpl/payments/default.php
@@ -37,7 +37,13 @@ use Joomla\CMS\Language\Text;
                 <td>$<?php echo number_format($payment->amount, 2); ?></td>
                 <td><?php echo $payment->status; ?></td>
                 <td>$<?php echo number_format($payment->fee_amount, 2); ?></td>
-                <td><?php echo $payment->payment_method; ?></td>
+                <td>
+                    <?php 
+                    $plugin = \Joomla\CMS\Plugin\PluginHelper::getPlugin('mothership-payment', $payment->payment_method);
+                    $pluginParams = new \Joomla\Registry\Registry($plugin->params);
+                    echo $pluginParams->get('display_name');
+                    ?>
+                </td>
                 <td><?php echo $payment->transaction_id; ?></td>
                 <td><a href="<?php echo Route::_('index.php?option=com_mothership&view=invoice&id=' . $payment->invoice_ids); ?>" ><?php echo $payment->invoice_ids; ?></a></td>
             </tr>


### PR DESCRIPTION
# Summary
Adds a `Thank You` page as well as a new payment method `Pay By Check` which is basically a clone of `Zelle`. Both require admin confirmation to be completed.

## Changes
- Fixes #23 
- Fixes #48 
- Changes the way that payments process. Instead of using a Joomla based event, the plugin classes are directly called. All plugins initially call a `initiate()` function which starts the plugin payment process whatever it is.
- Adds a controller for activating plugin methods to make it easier for payment plugins to be customizable
- Changes the payment flow to insert a payment record when payment is initiated. A `mothership_invoice_payment` record is also created immediately so that the payment and the invoice are visually connected.
- Adds a new payment status for `Pending` payments.
- Hides the `Pay` link if the payment is in a pending state