### PR TITLE
Bugfix Log Views

### DIFF
--- a/.github/workflows/codeception.tests.yml
+++ b/.github/workflows/codeception.tests.yml
@@ -109,7 +109,9 @@ jobs:
         run: |
           mkdir -p test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}
           cp -v tests/_output/* test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}/ || true
-          cp -v tests/_output/debug/* test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}/ || true
+            if [ "${{ github.ref_name }}" = "main" ]; then
+            cp -v tests/_output/debug/* test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}/ || true
+            fi
           cp -v wp-content/debug.log test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}/ || true
           cp -v /var/log/php_errors.log test-artifacts/${{ matrix.suite }}-${{ matrix.group || 'default' }}/ || true
 

--- a/.github/workflows/codeception.tests.yml
+++ b/.github/workflows/codeception.tests.yml
@@ -34,6 +34,8 @@ jobs:
           - suite: acceptance
             group: backend-options
           - suite: acceptance
+            group: backend-log
+          - suite: acceptance
             group: frontend
 
     steps:

--- a/admin/forms/log.xml
+++ b/admin/forms/log.xml
@@ -2,13 +2,13 @@
 <form addfieldprefix="TrevorBice\Component\Mothership\Administrator\Field">
 	<fieldset name="details">
 		<field name="id" type="number" label="JGLOBAL_FIELD_ID_LABEL" default="0" readonly="true" class="readonly" />
-		<field name="client_id" type="clientlist" label="COM_MOTHERSHIP_FIELD_CLIENT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_CLIENT_NAME_DESC" required="true" class="" default="" readonly="" />
-		<field name="account_id" type="accountlist" label="COM_MOTHERSHIP_FIELD_ACCOUNT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_ACCOUNT_NAME_DESC" required="true" class="" default="" readonly="" />
-		<field name="user_id" type="text" label="COM_MOTHERSHIP_FIELD_USER_ID_LABEL" description="COM_MOTHERSHIP_FIELD_USER_ID_DESC" required="true" class="" default="" readonly="" />
-		<field name="object_type" type="text" label="COM_MOTHERSHIP_FIELD_OBJECT_TYPE_LABEL" description="COM_MOTHERSHIP_FIELD_OBJECT_TYPE_DESC" required="true" class="" default="" readonly="" />
-		<field name="object_id" type="text" label="COM_MOTHERSHIP_FIELD_OBJECT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_OBJECT_ID_DESC" required="true" class="" default="" readonly="" />
-		<field name="action" type="text" label="COM_MOTHERSHIP_FIELD_ACTION_LABEL" description="COM_MOTHERSHIP_FIELD_ACTION_DESC" required="true" class="" default="" readonly="" />
-		<field name="created" type="calendar" label="COM_MOTHERSHIP_FIELD_CREATED_LABEL" description="COM_MOTHERSHIP_FIELD_CREATED_DESC" required="true" class="" default="" readonly="" format="%Y-%m-%d %H:%M:%S" filter="user_utc" />
+		<field name="client_id" type="clientlist" label="COM_MOTHERSHIP_FIELD_CLIENT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_CLIENT_NAME_DESC" required="true" class="" default="" readonly="true" />
+		<field name="account_id" type="accountlist" label="COM_MOTHERSHIP_FIELD_ACCOUNT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_ACCOUNT_NAME_DESC" required="true" class="" default="" readonly="true" />
+		<field name="user_id" type="text" label="COM_MOTHERSHIP_FIELD_USER_ID_LABEL" description="COM_MOTHERSHIP_FIELD_USER_ID_DESC" required="true" class="" default="" readonly="true" />
+		<field name="object_type" type="text" label="COM_MOTHERSHIP_FIELD_OBJECT_TYPE_LABEL" description="COM_MOTHERSHIP_FIELD_OBJECT_TYPE_DESC" required="true" class="" default="" readonly="true" />
+		<field name="object_id" type="text" label="COM_MOTHERSHIP_FIELD_OBJECT_ID_LABEL" description="COM_MOTHERSHIP_FIELD_OBJECT_ID_DESC" required="true" class="" default="" readonly="true" />
+		<field name="action" type="text" label="COM_MOTHERSHIP_FIELD_ACTION_LABEL" description="COM_MOTHERSHIP_FIELD_ACTION_DESC" required="true" class="" default="" readonly="true" />
+		<field name="created" type="calendar" label="COM_MOTHERSHIP_FIELD_CREATED_LABEL" description="COM_MOTHERSHIP_FIELD_CREATED_DESC" required="true" class="" default="" readonly="true" format="%Y-%m-%d %H:%M:%S" filter="user_utc" />
 	</fieldset>
 	<fieldset name="metadata" label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 		<field name="metakey" type="textarea" label="JFIELD_META_KEYWORDS_LABEL" rows="3" cols="30" />

--- a/admin/language/en-GB/com_mothership.ini
+++ b/admin/language/en-GB/com_mothership.ini
@@ -404,8 +404,6 @@ COM_MOTHERSHIP_FIELD_PROJECT_TYPE_DESC="The type of project."
 ; -----------------------------------------------------------------
 ; Logs Manager & Form
 ; -----------------------------------------------------------------
-COM_MOTHERSHIP_MANAGER_LOG_NEW="Mothership: New Log"
-COM_MOTHERSHIP_MANAGER_LOG_EDIT="Mothership: Edit Log"
 COM_MOTHERSHIP_MANAGER_LOG_VIEW="Mothership: View Log"
 
 COM_MOTHERSHIP_FORM_LOG_DETAILS_TAB="Log Details"

--- a/admin/language/en-GB/com_mothership.ini
+++ b/admin/language/en-GB/com_mothership.ini
@@ -406,6 +406,7 @@ COM_MOTHERSHIP_FIELD_PROJECT_TYPE_DESC="The type of project."
 ; -----------------------------------------------------------------
 COM_MOTHERSHIP_MANAGER_LOG_NEW="Mothership: New Log"
 COM_MOTHERSHIP_MANAGER_LOG_EDIT="Mothership: Edit Log"
+COM_MOTHERSHIP_MANAGER_LOG_VIEW="Mothership: View Log"
 
 COM_MOTHERSHIP_FORM_LOG_DETAILS_TAB="Log Details"
 

--- a/admin/src/View/Log/HtmlView.php
+++ b/admin/src/View/Log/HtmlView.php
@@ -120,32 +120,8 @@ class HtmlView extends BaseHtmlView
         $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(
-            $isNew ? Text::_('COM_MOTHERSHIP_MANAGER_LOG_NEW') : Text::_('COM_MOTHERSHIP_MANAGER_LOG_EDIT'),
+            Text::_('COM_MOTHERSHIP_MANAGER_LOG_VIEW'),
             'bookmark mothership-logs'
-        );
-
-        // If not checked out, can save the item.
-        if (!$checkedOut && ($canDo->get('core.edit') || $canDo->get('core.create'))) {
-            $toolbar->apply('log.apply');
-        }
-
-        $saveGroup = $toolbar->dropdownButton('save-group');
-        $saveGroup->configure(
-            function (Toolbar $childBar) use ($checkedOut, $canDo, $isNew) {
-                // If not checked out, can save the item.
-                if (!$checkedOut && ($canDo->get('core.edit') || $canDo->get('core.create'))) {
-                    $childBar->save('log.save');
-                }
-
-                if (!$checkedOut && $canDo->get('core.create')) {
-                    $childBar->save2new('log.save2new');
-                }
-
-                // If an existing item, can save to a copy.
-                if (!$isNew && $canDo->get('core.create')) {
-                    $childBar->save2copy('log.save2copy');
-                }
-            }
         );
 
         if (empty($this->item->id)) {

--- a/admin/src/View/Logs/HtmlView.php
+++ b/admin/src/View/Logs/HtmlView.php
@@ -115,10 +115,6 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('COM_MOTHERSHIP_MANAGER_LOGS'), 'bookmark mothership-logs');
 
-        if ($canDo->get('core.create')) {
-            $toolbar->addNew('log.add');
-        }
-
         if (!$this->isEmptyState && ($canDo->get('core.edit.state') || $canDo->get('core.admin'))) {
             $dropdown = $toolbar->dropdownButton('status-group', 'JTOOLBAR_CHANGE_STATUS')
                 ->toggleSplit(false)

--- a/mothership.xml
+++ b/mothership.xml
@@ -40,9 +40,8 @@
 			<menu link="option=com_mothership&amp;view=projects" view="projects">com_mothership_projects</menu>
             <menu link="option=com_mothership&amp;view=domains" view="domains">com_mothership_domains</menu>
 			<menu link="option=com_mothership&amp;view=invoices" view="invoices">com_mothership_invoices</menu>
-			<menu link="option=com_mothership&amp;view=payments" view="payments">com_mothership_payments</menu>
             <menu link="option=com_mothership&amp;view=payments" view="payments">com_mothership_payments</menu>
-            <menu link="option=com_mothership&amp;view=payments" view="payments">com_mothership_logs</menu>
+            <menu link="option=com_mothership&amp;view=logs" view="logs">com_mothership_logs</menu>
         </submenu>
 
         <files folder="admin">

--- a/tests/_support/Helper/DbHelper.php
+++ b/tests/_support/Helper/DbHelper.php
@@ -598,6 +598,7 @@ class DbHelper extends Db
 
     public function createMothershipLogData(array $data)
     {
+
         $defaultData = [
             "client_id" => $data['client_id'] ?? 0,
             "account_id" => $data['account_id'] ?? 0,
@@ -610,6 +611,7 @@ class DbHelper extends Db
             "created" => date('Y-m-d H:i:s'),
             "notes" => $data['notes'] ?? '',
         ];
+        
 
         // Merge provided data with defaults
         $finalData = array_merge($defaultData, $data);

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -178,11 +178,11 @@ class MothershipAdminLogsCest
 
         $I->seeOptionIsSelected("select#jform_client_id", $this->clientData['name']);
         $I->seeOptionIsSelected("select#jform_account_id", $this->accountData['name']);
-        $I->seeInField("input#jform_user_id", $this->logData[0]['user_id']);
-        $I->seeInField("input#jform_object_type", $this->logData[0]['object_type']);
-        $I->seeInField("input#jform_object_id", $this->logData[0]['object_id']);
-        $I->seeInField("input#jform_action", $this->logData[0]['action']);
-        $I->seeInField("input#jform_created", $this->logData[0]['created']);
+        $I->seeInField("input#jform_user_id", "{$this->logData[0]['user_id']}");
+        $I->seeInField("input#jform_object_type", "{$this->logData[0]['object_type']}");
+        $I->seeInField("input#jform_object_id", "{$this->logData[0]['object_id']}");
+        $I->seeInField("input#jform_action", "{$this->logData[0]['action']}");
+        $I->seeInField("input#jform_created", "{$this->logData[0]['created']}");
         
         $I->click("Close", "#toolbar");
         $I->waitForText("Mothership: Logs", 20, "h1.page-title");

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -109,7 +109,7 @@ class MothershipAdminLogsCest
             'created'     => '2025-04-21 21:34:08',
         ]);
 
-        $this->logTextDescription[$this->logData[4]['id']] = "Domain ID 1 was viewed.";
+        $this->logTextDescription[$this->logData[4]['id']] = "Domain 1 was viewed.";
         $this->logTextDetails[$this->logData[4]['id']] = "Domain ID 1 was viewed by user ID 548.";
         
 
@@ -159,8 +159,8 @@ class MothershipAdminLogsCest
             $I->see("{$log['id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(2)");
             $I->see("{$this->clientData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(3)");
             $I->see("{$this->accountData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(4)");
-            $I->see($this->logTextDescription[$log['id']], "#j-main-container table thead tr th:nth-child(5)");
-            $I->see($this->logTextDetails[$log['id']], "#j-main-container table thead tr th:nth-child(6)");
+            $I->see($this->logTextDescription[$log['id']], "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(5)");
+            $I->see($this->logTextDetails[$log['id']], "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(6)");
             $I->see("{$log['object_type']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(7)");
             $I->see("{$log['object_id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(8)");
             $I->see("{$log['action']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(9)");

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -9,8 +9,9 @@ use DateTimeZone;
 
 class MothershipAdminLogsCest
 {
-    private $logData;
+    private $logData=[];
     private $userData;
+    private $clientData;
     private $accountData;
     private $invoiceData;
     private $paymentData;
@@ -23,10 +24,75 @@ class MothershipAdminLogsCest
     {
         $I->resetMothershipTables();
 
-        $this->logData = $I->createMothershipLog([
-            'description' => 'Test Log',
-            'details' => 'Test Log Details',
+        $this->clientData = $I->createMothershipClient([
+            'name' => 'Test Client',
         ]);
+
+        $this->accountData = $I->createMothershipAccount([
+            'client_id' => $this->clientData['id'],
+            'name' => 'Test Account',
+        ]);
+        $this->logData[] = $I->createMothershipLog([
+            'client_id'   => $this->clientData['id'],
+            'account_id'  => $this->accountData['id'],
+            'user_id'     => 548,
+            'object_id'   => 93,
+            'object_type' => 'payment',
+            'action'      => 'viewed',
+            'meta'        => json_encode([]),
+            'created'     => '2025-04-11 01:29:03',
+        ]);
+        
+        $this->logData[] = $I->createMothershipLog([
+            'client_id'   => 1,
+            'account_id'  => 1,
+            'user_id'     => 548,
+            'object_id'   => 93,
+            'object_type' => 'payment',
+            'action'      => 'status_changed',
+            'meta'        => json_encode([
+                'new_status' => 'Pending',
+                'old_status' => 'Completed',
+            ]),
+            'created'     => '2025-04-11 01:32:21',
+        ]);
+        
+        $this->logData[] = $I->createMothershipLog([
+            'client_id'   => 1,
+            'account_id'  => 1,
+            'user_id'     => 548,
+            'object_id'   => 2,
+            'object_type' => 'invoice',
+            'action'      => 'viewed',
+            'meta'        => json_encode([]),
+            'created'     => '2025-04-11 01:45:19',
+        ]);
+        
+        $this->logData[] = $I->createMothershipLog([
+            'client_id'   => 1,
+            'account_id'  => 1,
+            'user_id'     => 548,
+            'object_id'   => 97,
+            'object_type' => 'payment',
+            'action'      => 'initiated',
+            'meta'        => json_encode([
+                'invoice_id'     => 2,
+                'payment_method' => 'Paypal',
+            ]),
+            'created'     => '2025-04-11 01:59:16',
+        ]);
+        
+        $this->logData[] = $I->createMothershipLog([
+            'client_id'   => 1,
+            'account_id'  => 1,
+            'user_id'     => 548,
+            'object_id'   => 1,
+            'object_type' => 'domain',
+            'action'      => 'viewed',
+            'meta'        => json_encode([]),
+            'created'     => '2025-04-21 21:34:08',
+        ]);
+        
 
         $I->amOnPage("/administrator/");
         $I->fillField("input[name=username]", "admin");
@@ -41,7 +107,7 @@ class MothershipAdminLogsCest
      * @group log
      * @group backend-log
      */
-    public function MothershipViewLogs(AcceptanceTester $I)
+    public function MothershipViewAllLogs(AcceptanceTester $I)
     {
         $I->amOnPage(self::LOGS_VIEW_ALL_URL);
         $I->waitForText("Mothership: Logs", 20, "h1.page-title");
@@ -50,30 +116,39 @@ class MothershipAdminLogsCest
 
         $toolbar = "#toolbar";
         $toolbarNew = "#toolbar-new";
-        $toolbarStatusGroup = "#toolbar-status-group";
-        $I->seeElement("{$toolbar} {$toolbarNew}");
-        $I->see("New", "{$toolbar} {$toolbarNew} .btn.button-new");
+        // New Logs Can't Be Created
+        $I->dontSeeElement("{$toolbar} {$toolbarNew}");
+        $I->dontSee("New", "{$toolbar} {$toolbarNew} .btn.button-new");
 
         $I->seeElement("#j-main-container ");
         $I->seeElement("#j-main-container thead");
 
-        $I->see("Log Name Asc");
+        $I->seeNumberOfElements("#j-main-container table.itemList tbody tr", 5);
 
-        $I->see("Id", "#j-main-container table thead tr th:nth-child(2)");
-        $I->see("Name", "#j-main-container table thead tr th:nth-child(3)");
-        $I->see("Phone", "#j-main-container table thead tr th:nth-child(4)");
-        $I->see("Default Rate", "#j-main-container table thead tr th:nth-child(5)");
-        $I->see("Created", "#j-main-container table thead tr th:nth-child(6)");
+        $I->see("ID", "#j-main-container table thead tr th:nth-child(2)");
+        $I->see("Client Name", "#j-main-container table thead tr th:nth-child(3)");
+        $I->see("Account Name", "#j-main-container table thead tr th:nth-child(4)");
+        $I->see("Description", "#j-main-container table thead tr th:nth-child(5)");
+        $I->see("Details", "#j-main-container table thead tr th:nth-child(6)");
+        $I->see("Object Type", "#j-main-container table thead tr th:nth-child(7)");
+        $I->see("Object ID", "#j-main-container table thead tr th:nth-child(8)");
+        $I->see("Action", "#j-main-container table thead tr th:nth-child(9)");
+        $I->see("Created", "#j-main-container table thead tr th:nth-child(10)");
 
-        $I->see("1", "#j-main-container table tbody tr td:nth-child(2)");
-        $I->see("Test Log", "#j-main-container table tbody tr td:nth-child(3)");
-        $I->see($this->logData['phone'], "#j-main-container table tbody tr td:nth-child(4)");
-        $I->see("$100.00", "#j-main-container table tbody tr td:nth-child(5)");
-        $I->see(date("Y-m-d"), "#j-main-container table tbody tr td:nth-child(6)");
-
-        $I->seeNumberOfElements("#j-main-container table.itemList tbody tr", 1);
-
-        $I->see("1 - 1 / 1 items", "#j-main-container .pagination__wrapper");
+        foreach(array_reverse($this->logData) as $index=>$log) {
+            $realIndex = $index+1;
+            $I->see("{$log['id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(2)");
+            $I->see("{$this->clientData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(3)");
+            $I->see("{$this->accountData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(4)");
+            // $I->see("Description", "#j-main-container table thead tr th:nth-child(5)");
+            // $I->see("Details", "#j-main-container table thead tr th:nth-child(6)");
+            $I->see("{$log['object_type']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(7)");
+            $I->see("{$log['object_id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(8)");
+            $I->see("{$log['action']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(9)");
+            $I->see("{$log['created']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(10)");
+        }
+       
+        $I->see("1 - 5 / 5 items", "#j-main-container .pagination__wrapper");
     }
 
     /**
@@ -81,186 +156,17 @@ class MothershipAdminLogsCest
      * @group log
      * @group backend-log
      */
-    public function MothershipAddLog(AcceptanceTester $I)
+    public function MothershipViewLog(AcceptanceTester $I)
     {
-        $I->amOnPage(self::LOGS_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Logs", 20, "h1.page-title");
+        $I->amOnPage(sprintf(self::LOG_EDIT_URL, $this->logData[0]['id']));
+        $I->waitForText("Mothership: View Log", 20, "h1.page-title");
+
+        $I->makeScreenshot("mothership-log-view");
 
         $toolbar = "#toolbar";
-        $toolbarNew = "#toolbar-new";
-        $toolbarStatusGroup = "#toolbar-status-group";
-        $I->seeElement("{$toolbar} {$toolbarNew}");
-        $I->see("New", "{$toolbar} {$toolbarNew} .btn.button-new");
-
-        $I->click("{$toolbar} {$toolbarNew} .btn.button-new");
-        $I->waitForText("Mothership: New Log", 20, "h1.page-title");
-
-        $I->makeScreenshot("mothership-log-add-details");
-
-        $I->see("Save", "#toolbar");
-        $I->see("Save & Close", "#toolbar");
-        $I->see("Cancel", "#toolbar");
-
-        $I->seeElement("form[name=adminForm]");
-        $I->seeElement("form#log-form");
-
-        $I->seeElement("#myTab");
-        $I->see("Log Details", "#myTab");
-
-        $I->seeElement("input#jform_name");
-        $I->seeElement("input#jform_email");
-        $I->seeElement("input#jform_phone");
-        $I->seeElement("input#jform_address_1");
-        $I->seeElement("input#jform_address_2");
-        $I->seeElement("input#jform_city");
-        $I->seeElement("select#jform_state");
-        $I->seeElement("input#jform_zip");
-        $I->seeElement("input#jform_default_rate");
-        $I->seeElement("input#jform_owner_user_id");
-
-        $I->fillField("input#jform_name", "Another Log");
-        $I->fillField("input#jform_email", "another.log@mailinator.com");
-        $I->fillField("input#jform_phone", "(555) 555-5555");
-        $I->fillField("input#jform_address_1", "12345 St.");
-        $I->fillField("input#jform_address_2", "APT 123");
-        $I->fillField("input#jform_city", "City");
-        $I->selectOption("select#jform_state", "California");
-        $I->fillField("input#jform_zip", "95524");
-        $I->fillField("input#jform_default_rate", "100.00");
-
-        $I->click(".icon-user");
-        $I->makeScreenshot("mothership-log-add-contact");
-        $I->switchToIFrame(".iframe-content");       
-        $I->fillFIeld("#filter_search", $this->joomlaUserData['name']);
-        $I->click('//button[contains(@class, "btn") and .//span[contains(@class, "icon-search")]]');
-        $I->wait(3);
-        $I->click($this->joomlaUserData['name']);
-        $I->wait(1);
-        $I->switchToIFrame();
-
-        $I->click("Save & Close", "#toolbar");
-        $I->wait(3);
-        $I->seeInCurrentUrl(("/administrator/index.php?option=com_mothership&view=logs"));
-        $I->see("Log saved", ".alert-message");
-
-        $I->seeInCurrentUrl(self::LOGS_VIEW_ALL_URL);
-        $I->seeNumberOfElements("#j-main-container table tbody tr", 2);
-
-        $log_id = $I->grabTextFrom("#j-main-container table tbody tr:nth-child(1) td:nth-child(2)");
-
-        $I->see($log_id . "", "#j-main-container table tbody tr:nth-child(1) td:nth-child(2)");
-        $I->see("Another Log", "#j-main-container table tbody tr:nth-child(1) td:nth-child(3)");
-        $I->see((new DateTime('now', new DateTimeZone('America/Los_Angeles')))->format('Y-m-d'), "#j-main-container table tbody tr:nth-child(1) td:nth-child(6)");
-
-        $I->seeInDatabase("jos_mothership_logs", [
-            'name' => 'Another Log',
-            'email' => 'another.log@mailinator.com',
-            'phone' => '(555) 555-5555',
-            'address_1' => '12345 St.',
-            'address_2' => 'APT 123',
-            'city' => 'City',
-            'state' => 'CA',
-            'zip' => '95524',
-            'default_rate' => '100.00',
-            'tax_id' => '',
-            // 'created' => date("Y-m-d 00:00:00"),
-        ]);
-
-        // Open the Invoice again and confirm the data is correct
-        $I->amOnPage(sprintf(self::LOG_EDIT_URL, $log_id));
-        $I->click("Details");
-        // Confirm the value in jform_number is correct
-        $I->seeInField("input#jform_name", "Another Log");
-        $I->click("Save", "#toolbar");
-
-        $I->wait(1);
-        $I->see("Mothership: Edit Log", "h1.page-title");
-        $I->seeCurrentUrlEquals(sprintf(self::LOG_EDIT_URL, $log_id));
-        $I->see("Log Another Log saved successfully.", ".alert-message");
+        $toolbarCancel = "#toolbar-cancel";
+        $I->seeElement("{$toolbar} {$toolbarCancel}");
+        $I->see("Close", "{$toolbar} {$toolbarCancel} .btn.button-cancel");
     }
 
-    /**
-     * @group backend
-     * @group log
-     * @group delete
-     * @group backend-log
-     */
-    public function MothershipDeleteLogWithAccountsFailure(AcceptanceTester $I)
-    {
-        $I->seeInDatabase("jos_mothership_logs", [
-            'id' => $this->logData['id'],
-        ]);
-        $I->amOnPage(self::LOGS_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Logs", 20, "h1.page-title");
-
-        $I->seeNumberOfElements("#j-main-container table tbody tr", 1);
-        
-        $I->seeElement(".btn-toolbar");
-
-        $I->click("input[name=checkall-toggle]");
-        $I->click("Actions");
-        $I->see("Check-in", "joomla-toolbar-button#status-group-children-checkin");
-        $I->see("Delete", "joomla-toolbar-button#status-group-children-delete");
-        $I->seeElement("joomla-toolbar-button#status-group-children-delete", ['task' => "logs.delete"]);
-
-        $I->click("Delete", "#toolbar");
-        $I->wait(1);
-
-        $I->seeInCurrentUrl(self::LOGS_VIEW_ALL_URL);
-        $I->see("Mothership: Logs", "h1.page-title");
-        $I->see("Cannot delete log(s) [1] because they have one or more associated accounts.", ".alert-message");
-        $I->seeNumberOfElements("#j-main-container table tbody tr", 1);
-        $I->seeInDatabase("jos_mothership_logs", [
-            'id' => $this->logData['id'],
-        ]);
-        $I->seeInDatabase("jos_mothership_accounts", [
-            'log_id' => $this->logData['id'],
-        ]);
-    }
-
-    /**
-     * @group backend
-     * @group log
-     * @group delete
-     * @group backend-log
-     */
-    public function MothershipDeleteLogSuccess(AcceptanceTester $I)
-    {
-        $noAccountsLog = $I->createMothershipLog([
-            'description' => 'No Accounts Log',
-            'details' => 'No Accounts Log Details',
-        ]);
-
-        $I->amOnPage(self::LOGS_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Logs", 20, "h1.page-title");
-
-        $I->seeNumberOfElements("#j-main-container table tbody tr", 2);
-        
-        $I->seeElement(".btn-toolbar");
-
-        $I->click("input[name=checkall-toggle]");
-        $I->click("Actions");
-        $I->see("Check-in", "joomla-toolbar-button#status-group-children-checkin");
-        $I->seeElement("joomla-toolbar-button#status-group-children-checkin", ['task' => "logs.checkIn"]);
-        $I->see("Edit", "joomla-toolbar-button#status-group-children-edit");
-        $I->seeElement("joomla-toolbar-button#status-group-children-edit", ['task' => "log.edit"]);
-        $I->see("Delete", "joomla-toolbar-button#status-group-children-delete");
-        $I->seeElement("joomla-toolbar-button#status-group-children-delete", ['task' => "logs.delete"]);
-
-        $I->click("Delete", "#toolbar");
-        $I->wait(1);
-
-        $I->seeInCurrentUrl(self::LOGS_VIEW_ALL_URL);
-        $I->see("Mothership: Logs", "h1.page-title");
-        $I->see("Cannot delete log(s) [1] because they have one or more associated accounts.", ".alert-message");
-        $I->see("1 Log deleted successfully.", ".alert-message");
-        $I->seeNumberOfElements("#j-main-container table tbody tr", 1);
-
-        $I->seeInDatabase("jos_mothership_logs", [
-            'id' => $this->logData['id'],
-        ]);
-        $I->dontSeeInDatabase('jos_mothership_logs', [
-            'id' => $noAccountsLog['id'],
-        ]);
-    }
 }

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -167,6 +167,26 @@ class MothershipAdminLogsCest
         $toolbarCancel = "#toolbar-cancel";
         $I->seeElement("{$toolbar} {$toolbarCancel}");
         $I->see("Close", "{$toolbar} {$toolbarCancel} .btn.button-cancel");
+
+        $I->seeElement("select#jform_client_id");
+        $I->seeElement("select#jform_account_id");
+        $I->seeElement("input#jform_user_id");
+        $I->seeElement("input#jform_object_type");
+        $I->seeElement("input#jform_object_id");
+        $I->seeElement("input#jform_action");
+        $I->seeElement("input#jform_created");
+
+        $I->seeOptionIsSelected("select#jform_client_id", $this->clientData['name']);
+        $I->seeOptionIsSelected("select#jform_account_id", $this->accountData['name']);
+        $I->seeInField("input#jform_user_id", $this->logData[0]['user_id']);
+        $I->seeInField("input#jform_object_type", $this->logData[0]['object_type']);
+        $I->seeInField("input#jform_object_id", $this->logData[0]['object_id']);
+        $I->seeInField("input#jform_action", $this->logData[0]['action']);
+        $I->seeInField("input#jform_created", $this->logData[0]['created']);
+        
+        $I->click("Close", "#toolbar");
+        $I->waitForText("Mothership: Logs", 20, "h1.page-title");
+        
     }
 
 }

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -16,6 +16,8 @@ class MothershipAdminLogsCest
     private $invoiceData;
     private $paymentData;
     private $joomlaUserData;
+    private $logTextDescription = [];
+    private $logTextDetails = [];
 
     const LOGS_VIEW_ALL_URL = "/administrator/index.php?option=com_mothership&view=logs";
     const LOG_EDIT_URL = "/administrator/index.php?option=com_mothership&view=log&layout=edit&id=%s";
@@ -32,6 +34,9 @@ class MothershipAdminLogsCest
             'client_id' => $this->clientData['id'],
             'name' => 'Test Account',
         ]);
+
+        
+
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => $this->clientData['id'],
             'account_id'  => $this->accountData['id'],
@@ -42,6 +47,8 @@ class MothershipAdminLogsCest
             'meta'        => json_encode([]),
             'created'     => '2025-04-11 01:29:03',
         ]);
+        $this->logTextDescription[$this->logData[0]['id']] = "Payment ID 93 was viewed.";
+        $this->logTextDetails[$this->logData[0]['id']] = "Payment ID 93 was viewed by user ID 548.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -57,6 +64,9 @@ class MothershipAdminLogsCest
             'created'     => '2025-04-11 01:32:21',
         ]);
         
+        $this->logTextDescription[$this->logData[1]['id']] = "Payment status changed from `Completed` to `Pending`.";
+        $this->logTextDetails[$this->logData[1]['id']] = "Payment ID 93 status changed from `Completed` to `Pending` by user 548.";
+        
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
             'account_id'  => 1,
@@ -67,6 +77,9 @@ class MothershipAdminLogsCest
             'meta'        => json_encode([]),
             'created'     => '2025-04-11 01:45:19',
         ]);
+
+        $this->logTextDescription[$this->logData[2]['id']] = "Invoice ID 2 was viewed.";
+        $this->logTextDetails[$this->logData[2]['id']] = "Invoice ID 2 was viewed by user ID 548.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -81,6 +94,9 @@ class MothershipAdminLogsCest
             ]),
             'created'     => '2025-04-11 01:59:16',
         ]);
+
+        $this->logTextDescription[$this->logData[3]['id']] = "Payment ID 97 was initiated with method `Paypal` for invoice ID 2.";
+        $this->logTextDetails[$this->logData[3]['id']] = "Payment ID 97 was initiated with method `Paypal` for invoice ID 2 by user ID 548.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -92,6 +108,9 @@ class MothershipAdminLogsCest
             'meta'        => json_encode([]),
             'created'     => '2025-04-21 21:34:08',
         ]);
+
+        $this->logTextDescription[$this->logData[4]['id']] = "Domain ID 1 was viewed.";
+        $this->logTextDetails[$this->logData[4]['id']] = "Domain ID 1 was viewed by user ID 548.";
         
 
         $I->amOnPage("/administrator/");
@@ -140,8 +159,8 @@ class MothershipAdminLogsCest
             $I->see("{$log['id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(2)");
             $I->see("{$this->clientData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(3)");
             $I->see("{$this->accountData['name']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(4)");
-            // $I->see("Description", "#j-main-container table thead tr th:nth-child(5)");
-            // $I->see("Details", "#j-main-container table thead tr th:nth-child(6)");
+            $I->see($this->logTextDescription[$log['id']], "#j-main-container table thead tr th:nth-child(5)");
+            $I->see($this->logTextDetails[$log['id']], "#j-main-container table thead tr th:nth-child(6)");
             $I->see("{$log['object_type']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(7)");
             $I->see("{$log['object_id']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(8)");
             $I->see("{$log['action']}", "#j-main-container table tbody tr:nth-child({$realIndex}) td:nth-child(9)");

--- a/tests/acceptance/MothershipAdminLogsCest.php
+++ b/tests/acceptance/MothershipAdminLogsCest.php
@@ -48,7 +48,7 @@ class MothershipAdminLogsCest
             'created'     => '2025-04-11 01:29:03',
         ]);
         $this->logTextDescription[$this->logData[0]['id']] = "Payment ID 93 was viewed.";
-        $this->logTextDetails[$this->logData[0]['id']] = "Payment ID 93 was viewed by user ID 548.";
+        $this->logTextDetails[$this->logData[0]['id']] = "Payment ID 93 was viewed by user 548.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -79,7 +79,7 @@ class MothershipAdminLogsCest
         ]);
 
         $this->logTextDescription[$this->logData[2]['id']] = "Invoice ID 2 was viewed.";
-        $this->logTextDetails[$this->logData[2]['id']] = "Invoice ID 2 was viewed by user ID 548.";
+        $this->logTextDetails[$this->logData[2]['id']] = "Invoice ID 2 was viewed by user 548.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -95,8 +95,8 @@ class MothershipAdminLogsCest
             'created'     => '2025-04-11 01:59:16',
         ]);
 
-        $this->logTextDescription[$this->logData[3]['id']] = "Payment ID 97 was initiated with method `Paypal` for invoice ID 2.";
-        $this->logTextDetails[$this->logData[3]['id']] = "Payment ID 97 was initiated with method `Paypal` for invoice ID 2 by user ID 548.";
+        $this->logTextDescription[$this->logData[3]['id']] = "Payment ID 97 was initiated.";
+        $this->logTextDetails[$this->logData[3]['id']] = "Payment ID 97 using method Paypal was initiated by user 548 to pay invoice 2.";
         
         $this->logData[] = $I->createMothershipLog([
             'client_id'   => 1,
@@ -109,8 +109,8 @@ class MothershipAdminLogsCest
             'created'     => '2025-04-21 21:34:08',
         ]);
 
-        $this->logTextDescription[$this->logData[4]['id']] = "Domain 1 was viewed.";
-        $this->logTextDetails[$this->logData[4]['id']] = "Domain ID 1 was viewed by user ID 548.";
+        $this->logTextDescription[$this->logData[4]['id']] = "Domain `1` was viewed.";
+        $this->logTextDetails[$this->logData[4]['id']] = "Domain `1` was viewed by user 548.";
         
 
         $I->amOnPage("/administrator/");


### PR DESCRIPTION
# Summary
Restores the temporarily disabled log related acceptance tests. Does some re-thinking about users creating or editing logs.

## Changes
- Logs are not editable
- Admins cannot generate logs manually
- Tests updated to reflect these basic changes
- Re-Add Log Acceptance Tests to the CI/CD
- Update Log Acceptance tests
- `Mothership: Edit Log` is now `Mothership: View Log`
- All Log fields are readonly
- Remove Save or Apply buttons from the Log View and the New button from View All Logs
