### PR TITLE
111 bug warning is displayed when items are checked in on most view all pages

### DIFF
--- a/admin/tmpl/account/edit.php
+++ b/admin/tmpl/account/edit.php
@@ -57,7 +57,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/accounts/default.php
+++ b/admin/tmpl/accounts/default.php
@@ -68,7 +68,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php if ($item->checked_out) : ?>
-                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor ?? '', $item->checked_out_time, 'articles.', $canCheckin); ?>
                                         <?php endif; ?>
 
                                         <?php if ($canEdit || $canEditOwn) : ?>

--- a/admin/tmpl/client/edit.php
+++ b/admin/tmpl/client/edit.php
@@ -63,7 +63,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/clients/default.php
+++ b/admin/tmpl/clients/default.php
@@ -71,7 +71,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php if ($item->checked_out) : ?>
-                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor ?? '', $item->checked_out_time, 'articles.', $canCheckin); ?>
                                         <?php endif; ?>
 
                                         <?php if ($canEdit || $canEditOwn) : ?>

--- a/admin/tmpl/domain/edit.php
+++ b/admin/tmpl/domain/edit.php
@@ -70,7 +70,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/domains/default.php
+++ b/admin/tmpl/domains/default.php
@@ -80,7 +80,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     </td>
                                     <td>
                                         <?php if ($item->checked_out) : ?>
-                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'domains.', $canCheckin); ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor ?? '', $item->checked_out_time, 'domains.', $canCheckin); ?>
                                         <?php endif; ?>
 
                                         <?php if ($canEdit || $canEditOwn) : ?>

--- a/admin/tmpl/invoice/edit.php
+++ b/admin/tmpl/invoice/edit.php
@@ -92,7 +92,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/log/edit.php
+++ b/admin/tmpl/log/edit.php
@@ -67,7 +67,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/payment/edit.php
+++ b/admin/tmpl/payment/edit.php
@@ -62,8 +62,8 @@ $user = $this->getCurrentUser();
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
     </div>
 
-    <input type="hidden" name="jform[id]" value="<?php echo (int) $this->item->id; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return']) ? $_REQUEST['return'] : ''; ?>" />
+    <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/admin/tmpl/project/edit.php
+++ b/admin/tmpl/project/edit.php
@@ -61,7 +61,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
     </div>
 
     <input type="hidden" name="jform[id]" value="<?php echo (isset($this->item->id) && $this->item->id > 0) ? (int) $this->item->id : ""; ?>" />
-    <input type="hidden" name="jform[return]" value="<?php echo $_REQUEST['return']; ?>" />
+    <input type="hidden" name="jform[return]" value="<?php echo isset($_REQUEST['return'])?$_REQUEST['return']:''; ?>" />
     <input type="hidden" name="task" value="" />
     <?php echo JHtml::_('form.token'); ?>
 </form>

--- a/admin/tmpl/projects/default.php
+++ b/admin/tmpl/projects/default.php
@@ -74,7 +74,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
                                     <td>
                                         <?php $metadata = json_decode($item->metadata, true); ?>
                                         <?php if ($item->checked_out) : ?>
-                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+                                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor ?? '', $item->checked_out_time, 'articles.', $canCheckin); ?>
                                         <?php endif; ?>
 
                                         <?php if($metadata['status'] == 'online'):?>

--- a/site/src/Helper/MothershipHelper.php
+++ b/site/src/Helper/MothershipHelper.php
@@ -18,8 +18,9 @@ class MothershipHelper
     {
        
 
+        $user = Factory::getUser();
+
         if ($userId === null) {
-            $user = Factory::getUser();
             $userId = $user->id;
         }
 

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -41,7 +41,7 @@ use Joomla\CMS\Language\Text;
                 <td><?php echo $invoice->status; ?></td>
                 <td>
                     <?php echo $invoice->payment_status; ?><br/>
-                    <?php $payment_ids = array_filter(explode(",", $invoice->payment_ids)); ?>
+                    <?php $payment_ids = array_filter(explode(",", $invoice->payment_ids ?? '')); ?>
                     <?php if (count($payment_ids) > 0): ?>
                     <ul style="margin-bottom:0px;">
                         <?php foreach ($payment_ids as $paymentId): ?>

--- a/tests/acceptance/MothershipAdminAccountsCest.php
+++ b/tests/acceptance/MothershipAdminAccountsCest.php
@@ -87,6 +87,8 @@ class MothershipAdminAccountsCest
         
         $I->makeScreenshot("mothership-accounts-view-all");
 
+        $I->dontSee("Warning");
+
         $toolbar = "#toolbar";
         $toolbarNew = "#toolbar-new";
         $toolbarStatusGroup = "#toolbar-status-group";

--- a/tests/acceptance/MothershipAdminClientsCest.php
+++ b/tests/acceptance/MothershipAdminClientsCest.php
@@ -116,6 +116,7 @@ class MothershipAdminClientsCest
         $I->waitForText("Mothership: New Client", 20, "h1.page-title");
 
         $I->makeScreenshot("mothership-client-add-details");
+        $I->dontSee("Warning");
 
         $I->see("Save", "#toolbar");
         $I->see("Save & Close", "#toolbar");
@@ -159,7 +160,7 @@ class MothershipAdminClientsCest
         $I->switchToIFrame();
 
         $I->click("Save & Close", "#toolbar");
-        $I->wait(3);
+        $I->waitForText("Mothership: Clients", 20, "h1.page-title");
         $I->seeInCurrentUrl(("/administrator/index.php?option=com_mothership&view=clients"));
         $I->see("Client saved", ".alert-message");
 

--- a/tests/configuration.php
+++ b/tests/configuration.php
@@ -28,7 +28,7 @@ class JConfig {
 	public $live_site = 'http://joomla';
 	public $secret = 'RANDOM_SECRET'; // Can be anything random
 	public $gzip = false;
-	public $error_reporting = 'none';
+	public $error_reporting = 'maximum';
 	public $helpurl = 'https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&lang={langcode}';
 	public $offset = 'UTC';
 	public $mailonline = true;


### PR DESCRIPTION
# Summary
Bug can be reproduced by clicking `Save & Close` on the following objects: Clients, Accounts, Projects, Domains, Payments. This  eliminates the warnings.

```
Warning: Undefined property: stdClass::$editor in /volume1/tbwebdesign/www/mothership.trevorbice.com/app/public/administrator/components/com_mothership/tmpl/clients/default.php on line 74
```

## Changes
- Fixes #111 
- Fixes another warning happening on most of the objects in the footer when the `return` value is not being passed.