### PR TITLE
131 bug add loghelper integration tests

### DIFF
--- a/admin/src/Controller/PaymentController.php
+++ b/admin/src/Controller/PaymentController.php
@@ -8,6 +8,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use TrevorBice\Component\Mothership\Administrator\Helper\MothershipHelper;
 use TrevorBice\Component\Mothership\Administrator\Helper\LogHelper;
+use TrevorBice\Component\Mothership\Administrator\Helper\PaymentHelper;
 
 \defined('_JEXEC') or die;
 
@@ -77,6 +78,7 @@ class PaymentController extends FormController
         $redirect = MothershipHelper::getReturnRedirect($defaultRedirect);
 
         LogHelper::logStatusChange($payment, 'Completed');
+        PaymentHelper::onPaymentCompleted($payment);
 
         $this->setRedirect($redirect);
 

--- a/admin/src/Helper/LogHelper.php
+++ b/admin/src/Helper/LogHelper.php
@@ -132,13 +132,13 @@ class LogHelper extends ContentHelper
         self::logPaymentLifecycle('failed', 0, $paymentId, null, null, 0.0, '', $reason);
     }
 
-    public static function logObjectViewed($object_type, $object_id, $client_id, $account_id): void
+    public static function logObjectViewed($object_type, $object_id, $client_id, $account_id): bool
     {
         $user = Factory::getUser();
         $userId = $user->id;
         $username = $user->name ?: $user->username;
 
-        self::log([
+        if(self::log([
             'client_id' => $client_id,
             'account_id' => $account_id,
             'object_type' => $object_type,
@@ -146,7 +146,10 @@ class LogHelper extends ContentHelper
             'action' => 'viewed',
             'meta' =>[],
             'user_id' => $userId,
-        ]);
+        ])) {
+            return true;
+        }
+        return false;
     }
 
     public static function logDomainViewed($client_id, $account_id, $domain_id): void

--- a/admin/src/Helper/LogHelper.php
+++ b/admin/src/Helper/LogHelper.php
@@ -123,8 +123,21 @@ class LogHelper extends ContentHelper
         $accountId = $payment->account_id ?? null;
         $invoiceTotal = $payment->amount ?? 0.0;
         $paymentMethod = $payment->payment_method ?? '';
+        $user = Factory::getUser();
+        $userId = $user->id;
         
-        self::logPaymentLifecycle('completed', $invoiceId, $paymentId, $clientId, $accountId, $invoiceTotal, $paymentMethod);
+        self::log([
+            'client_id' => $clientId,
+            'account_id' => $accountId,
+            'object_type' => 'payment',
+            'object_id' => $paymentId,
+            'action' => 'payment_status_changed',
+            'meta' =>[
+                'old_status' => 'Pending',
+                'new_status' => 'Completed',
+            ],
+            'user_id' => $userId,
+        ]);
     }
 
     public static function logPaymentFailed($paymentId, ?string $reason = null): void

--- a/admin/src/Helper/PaymentHelper.php
+++ b/admin/src/Helper/PaymentHelper.php
@@ -77,7 +77,7 @@ class PaymentHelper
         \Joomla\CMS\Factory::getApplication()->triggerEvent('onMothershipPaymentCompleted', [$payment]);
 
         // SEnd the invoice template to the client
-        EmailService::sendTemplate('payment', 'test.smith@mailinator.com', 'Payment Completed', [
+        EmailService::sendTemplate('payment.confirmed', 'test.smith@mailinator.com', 'Payment Completed', [
             'fname' => 'Trevor',
             'invoice_number' => 'INV-2045',
             'account_name' => 'Trevor Bice Webdesign',

--- a/admin/src/Helper/PaymentHelper.php
+++ b/admin/src/Helper/PaymentHelper.php
@@ -67,13 +67,6 @@ class PaymentHelper
 
     public static function onPaymentCompleted($payment)
     {
-        // Log the event or trigger plugins here
-        \Joomla\CMS\Log\Log::add(
-            sprintf('Invoice #%d status changed from %d to Opened.', $payment->id, $previousStatus),
-            \Joomla\CMS\Log\Log::INFO,
-            'com_mothership'
-        );
-
         \Joomla\CMS\Factory::getApplication()->triggerEvent('onMothershipPaymentCompleted', [$payment]);
 
         // SEnd the invoice template to the client

--- a/tests/integration/MothershipLogHelperTest.php
+++ b/tests/integration/MothershipLogHelperTest.php
@@ -41,13 +41,13 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
         $this->domainData = $this->tester->createMothershipDomain([
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
-            'project_id' => $this->projectData['id'],
             'name' => 'google.com',
         ]);
 
         $this->invoiceData = $this->tester->createMothershipInvoice([
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
+            'project_id' => $this->projectData['id'],
             'total' => 175.00,
             'status' => '2',
         ]);

--- a/tests/integration/MothershipLogHelperTest.php
+++ b/tests/integration/MothershipLogHelperTest.php
@@ -13,6 +13,8 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
     protected $accountData;
     protected $invoiceData;
     protected $paymentData;
+    protected $projectData;
+    protected $domainData;
 
     protected function _before()
     {
@@ -27,6 +29,20 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
         $this->accountData = $this->tester->createMothershipAccount([
             'client_id' => $this->clientData['id'],
             'name' => 'Test Account',
+        ]);
+
+        $this->projectData = $this->tester->createMothershipProject([
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'name' => 'Test Project',
+            'type' => 'website',
+        ]);
+
+        $this->domainData = $this->tester->createMothershipDomain([
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'project_id' => $this->projectData['id'],
+            'name' => 'google.com',
         ]);
 
         $this->invoiceData = $this->tester->createMothershipInvoice([
@@ -70,6 +86,61 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
             'object_id' => $this->invoiceData['id'],
             'action' => 'viewed',
             'user_id' => 1,
+        ]);
+    }
+
+    public function objectTypeProvider()
+    {
+        return [
+            'client' => ['client'],
+            'account' => ['account'],
+            'project' => ['project'],
+            'domain' => ['domain'],
+            'invoice' => ['invoice'],
+            'payment' => ['payment'],
+        ];
+    }
+
+    /**
+     * @dataProvider objectTypeProvider
+     */
+    public function testLogObjectViewed($objectType)
+    {
+        switch($objectType){
+            case 'invoice':
+                $objectId = $this->invoiceData['id'];
+                break;
+            case 'payment':
+                $objectId = $this->paymentData['id'];
+                break;
+            case 'project':
+                $objectId = $this->projectData['id'];
+                break;
+            case 'client':
+                $objectId = $this->clientData['id'];
+                break;
+            case 'account':
+                $objectId = $this->accountData['id'];
+                break;
+            case 'domain':
+                $objectId = $this->domainData['id'];
+                break;
+            default:
+                $this->fail("Invalid object type: $objectType");
+        }
+        codecept_debug("Logging object viewed: $objectType with ID: $objectId");
+        $result = LogHelper::logObjectViewed($objectType, $objectId, $this->clientData['id'], $this->accountData['id']);
+        codecept_debug($result);
+
+        $this->assertTrue($result, 'Log entry was not created successfully.');
+
+        $this->tester->seeInDatabase('jos_mothership_logs', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => $objectType,
+            'object_id' => $objectId,
+            'action' => 'viewed',
+            // 'user_id' => 1,
         ]);
     }
 }

--- a/tests/integration/MothershipLogHelperTest.php
+++ b/tests/integration/MothershipLogHelperTest.php
@@ -143,4 +143,35 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
             // 'user_id' => 1,
         ]);
     }
+
+    public function testLogDomainScanned()
+    {
+        $result = LogHelper::logDomainScanned($this->domainData['id'], $this->clientData['id'], $this->accountData['id']);
+        codecept_debug($result);
+
+
+        $this->tester->seeInDatabase('jos_mothership_logs', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'domain',
+            'object_id' => $this->domainData['id'],
+            'action' => 'scanned',
+            // 'user_id' => 1,
+        ]);
+    }
+
+    public function testLogProjectScanned()
+    {
+        $result = LogHelper::logProjectScanned($this->projectData['id'], $this->clientData['id'], $this->accountData['id']);
+        codecept_debug($result);
+
+        $this->tester->seeInDatabase('jos_mothership_logs', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'project',
+            'object_id' => $this->projectData['id'],
+            'action' => 'scanned',
+            // 'user_id' => 1,
+        ]);
+    }
 }

--- a/tests/integration/MothershipLogHelperTest.php
+++ b/tests/integration/MothershipLogHelperTest.php
@@ -45,4 +45,31 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
             'payment_method' => 'manual'
         ]);
     }
+
+    public function testLog()
+    {
+        $params = [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'invoice',
+            'object_id' => $this->invoiceData['id'],
+            'action' => 'viewed',
+            'meta' => [],
+            'user_id' => 1,
+        ];
+
+        $result = LogHelper::log($params);
+        codecept_debug($result);
+
+        $this->assertTrue($result, 'Log entry was not created successfully.');
+
+        $this->tester->seeInDatabase('jos_mothership_logs', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'invoice',
+            'object_id' => $this->invoiceData['id'],
+            'action' => 'viewed',
+            'user_id' => 1,
+        ]);
+    }
 }

--- a/tests/integration/MothershipLogHelperTest.php
+++ b/tests/integration/MothershipLogHelperTest.php
@@ -174,4 +174,39 @@ class MothershipLogHelperTest extends \Codeception\Test\Unit
             // 'user_id' => 1,
         ]);
     }
+
+    public function testLogPaymentCompleted()
+    {
+
+        codecept_debug((object) $this->paymentData);
+
+        try {
+            $result = LogHelper::logPaymentCompleted((object) $this->paymentData);
+        } catch (\Exception $e) {
+            codecept_debug($e->getMessage());
+            $this->fail("Log entry was not created successfully: " . $e->getMessage());
+        }
+
+        codecept_debug("Test Log Payment Completed");
+        $metadata = json_decode($this->tester->grabFromDatabase('jos_mothership_logs', 'meta', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'payment',
+            'object_id' => $this->paymentData['id'],
+            'action' => 'payment_status_changed',
+        ]), true);
+        $this->assertArrayHasKey('new_status', $metadata);
+        $this->assertArrayHasKey('old_status', $metadata);
+        $this->assertEquals('Completed', $metadata['new_status']);
+        $this->assertEquals('Pending', $metadata['old_status']);
+
+        $this->tester->seeInDatabase('jos_mothership_logs', [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'object_type' => 'payment',
+            'object_id' => $this->paymentData['id'],
+            'action' => 'payment_status_changed',
+            // 'user_id' => 1,
+        ]);
+    }
 }


### PR DESCRIPTION
# Summary
Add tests for the LogHelper to ensure the logging system is working properly.

## Changes
- Fixes #131 
- Adds the `onPaymentComplete` event to be fired on payment controller `confirm`.
- Updates the `onPaymentComplete` method in the `PaymentHelper` to use the template `payment.complete` instead of `payment`