### PR TITLE
Bugfix edit invalid invoice

### DIFF
--- a/admin/language/en-GB/com_mothership.ini
+++ b/admin/language/en-GB/com_mothership.ini
@@ -99,6 +99,8 @@ COM_MOTHERSHIP_HEADING_ACCOUNT_CLIENT_NAME_DESC="Client Name Desc"
 COM_MOTHERSHIP_HEADING_ACCOUNT_CREATED_ASC="Created Asc"
 COM_MOTHERSHIP_HEADING_ACCOUNT_CREATED_DESC="Created Desc"
 
+COM_MOTHERSHIP_ERROR_ACCOUNT_NOT_FOUND="Account not found. Please select a valid account."
+
 ; -----------------------------------------------------------------
 ; Invoices Manager & Form
 ; -----------------------------------------------------------------
@@ -290,6 +292,8 @@ COM_MOTHERSHIP_CONFIRM_PAYMENT="Confirm Payment"
 COM_MOTHERSHIP_PAYMENT_CONFIRMED_SUCCESSFULLY="Payment %s confirmed successfully."
 COM_MOTHERSHIP_PAYMENT_CONFIRM_FAILED="Payment confirmation failed."
 
+COM_MOTHERSHIP_ERROR_PAYMENT_NOT_FOUND="Payment not found. Please select a valid payment."
+
 ; -----------------------------------------------------------------
 ; Domains Manager & Form
 ; -----------------------------------------------------------------
@@ -374,6 +378,8 @@ COM_MOTHERSHIP_FIELD_DOMAIN_NS4_DESC="The fourth nameserver for this domain."
 
 COM_MOTHERSHIP_MANAGER_LOGS="Mothership: Logs"
 
+COM_MOTHERSHIP_ERROR_DOMAIN_NOT_FOUND="Domain not found. Please select a valid domain."
+
 
 ; -----------------------------------------------------------------
 ; Projects & Form
@@ -425,6 +431,8 @@ COM_MOTHERSHIP_PROJECT_HEADING_TYPE="Type"
 
 COM_MOTHERSHIP_FIELD_PROJECT_TYPE_LABEL="Type"
 COM_MOTHERSHIP_FIELD_PROJECT_TYPE_DESC="The type of project."
+
+COM_MOTHERSHIP_ERROR_PROJECT_NOT_FOUND="Project not found. Please select a valid project."
 
 
 ; -----------------------------------------------------------------

--- a/admin/src/Model/InvoiceModel.php
+++ b/admin/src/Model/InvoiceModel.php
@@ -105,6 +105,10 @@ class InvoiceModel extends AdminModel
     {
         $item = parent::getItem($pk);
 
+        if(!is_object($item)) {
+            return false;
+        }
+
         if ($item && $item->id) {
             $db = $this->getDatabase();
             $query = $db->getQuery(true)

--- a/admin/src/View/Account/HtmlView.php
+++ b/admin/src/View/Account/HtmlView.php
@@ -81,8 +81,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var AccountModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_ACCOUNT_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=accounts', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->helper = new MothershipHelper;
         $this->canDo = ContentHelper::getActions('com_mothership');

--- a/admin/src/View/Client/HtmlView.php
+++ b/admin/src/View/Client/HtmlView.php
@@ -80,8 +80,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var ClientModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_CLIENT_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=clients', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->canDo = ContentHelper::getActions('com_mothership');
 

--- a/admin/src/View/Domain/HtmlView.php
+++ b/admin/src/View/Domain/HtmlView.php
@@ -81,8 +81,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var DomainModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_DOMAIN_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=domains', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->helper = new MothershipHelper;
         $this->canDo = ContentHelper::getActions('com_mothership');

--- a/admin/src/View/Invoice/HtmlView.php
+++ b/admin/src/View/Invoice/HtmlView.php
@@ -81,8 +81,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var InvoiceModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_INVOICE_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=invoices', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->helper = new MothershipHelper;
         $this->canDo = ContentHelper::getActions('com_mothership');

--- a/admin/src/View/Payment/HtmlView.php
+++ b/admin/src/View/Payment/HtmlView.php
@@ -82,8 +82,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var PaymentModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_PAYMENT_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=payments', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->helper = new MothershipHelper;
         $this->canDo = ContentHelper::getActions('com_mothership');

--- a/admin/src/View/Project/HtmlView.php
+++ b/admin/src/View/Project/HtmlView.php
@@ -81,8 +81,14 @@ class HtmlView extends BaseHtmlView
     {
         /** @var ProjectModel $model */
         $model = $this->getModel();
-        $this->form = $model->getForm();
         $this->item = $model->getItem();
+        if ($this->item === false) {
+            // Redirect to the list view if no item is found
+            $app = Factory::getApplication();
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_PROJECT_NOT_FOUND'), 'error');
+            $app->redirect(Factory::getApplication()->input->get('return', 'index.php?option=com_mothership&view=projects', 'raw'));    
+        }
+        $this->form = $model->getForm();
         $this->state = $model->getState();
         $this->helper = new MothershipHelper;
         $this->canDo = ContentHelper::getActions('com_mothership');

--- a/tests/acceptance/MothershipAdminAccountsCest.php
+++ b/tests/acceptance/MothershipAdminAccountsCest.php
@@ -174,7 +174,7 @@ class MothershipAdminAccountsCest
     public function MothershipEditInvalidAccount(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::ACCOUNT_EDIT_URL, "9999"));
-        $I->waitForText("Account not found. Please select a valid account.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Account not found. Please select a valid account.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminAccountsCest.php
+++ b/tests/acceptance/MothershipAdminAccountsCest.php
@@ -169,6 +169,17 @@ class MothershipAdminAccountsCest
     /**
      * @group backend
      * @group account
+     * @group backend-account
+     */
+    public function MothershipEditInvalidAccount(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::ACCOUNT_EDIT_URL, "9999"));
+        $I->waitForText("Account not found. Please select a valid account.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
+     * @group account
      * @group delete
      * @group backend-account
      */

--- a/tests/acceptance/MothershipAdminClientsCest.php
+++ b/tests/acceptance/MothershipAdminClientsCest.php
@@ -211,7 +211,7 @@ class MothershipAdminClientsCest
     public function MothershipEditInvalidClient(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::CLIENT_EDIT_URL, "9999"));
-        $I->waitForText("Client not found. Please select a valid client.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Client not found. Please select a valid client.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminClientsCest.php
+++ b/tests/acceptance/MothershipAdminClientsCest.php
@@ -206,6 +206,17 @@ class MothershipAdminClientsCest
     /**
      * @group backend
      * @group client
+     * @group backend-client
+     */
+    public function MothershipEditInvalidClient(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::CLIENT_EDIT_URL, "9999"));
+        $I->waitForText("Client not found. Please select a valid client.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
+     * @group client
      * @group delete
      * @group backend-client
      */

--- a/tests/acceptance/MothershipAdminDomainsCest.php
+++ b/tests/acceptance/MothershipAdminDomainsCest.php
@@ -187,6 +187,17 @@ class MothershipAdminDomainsCest
     /**
      * @group backend
      * @group domain
+     * @group backend-domain
+     */
+    public function MothershipEditInvalidDomain(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::DOMAIN_EDIT_URL, "9999"));
+        $I->waitForText("Domain not found. Please select a valid domain.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
+     * @group domain
      * @group delete
      * @group backend-domain
      */

--- a/tests/acceptance/MothershipAdminDomainsCest.php
+++ b/tests/acceptance/MothershipAdminDomainsCest.php
@@ -192,7 +192,7 @@ class MothershipAdminDomainsCest
     public function MothershipEditInvalidDomain(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::DOMAIN_EDIT_URL, "9999"));
-        $I->waitForText("Domain not found. Please select a valid domain.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Domain not found. Please select a valid domain.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminInvoicesCest.php
+++ b/tests/acceptance/MothershipAdminInvoicesCest.php
@@ -706,7 +706,7 @@ class MothershipAdminInvoicesCest
     public function MothershipEditInvalidInvoice(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::INVOICE_EDIT_URL, "9999"));
-        $I->waitForText("Invoice not found. Please select a valid invoice.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Invoice not found. Please select a valid invoice.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminInvoicesCest.php
+++ b/tests/acceptance/MothershipAdminInvoicesCest.php
@@ -121,7 +121,7 @@ class MothershipAdminInvoicesCest
         $I->click("Test Client");
         $I->waitForText("Mothership: Edit Client", 10, "h1.page-title");
         $I->click("Close", "#toolbar");
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
     }
 
     /**
@@ -133,13 +133,13 @@ class MothershipAdminInvoicesCest
     public function MothershipCancelAccountEdit(AcceptanceTester $I)
     {
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $I->click("Test Account");
         $I->wait(1);
          $I->waitForText("Mothership: Edit Account", 10, "h1.page-title");
         $I->click("Close", "#toolbar");
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
     }
 
     /**
@@ -164,7 +164,7 @@ class MothershipAdminInvoicesCest
         ]);
 
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $I->click("Payment #{$paymentData['id']}");
         $I->waitForText("Mothership: Edit Payment", 10, "h1.page-title");
@@ -231,7 +231,7 @@ class MothershipAdminInvoicesCest
         ]);
 
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $I->makeScreenshot("mothership-view-invoices");
 
@@ -321,7 +321,7 @@ class MothershipAdminInvoicesCest
         $I->seeInDatabase('jos_mothership_invoices', ['id' => $this->invoiceData['id']]);
 
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $I->seeElement(".btn-toolbar");
 
@@ -407,7 +407,7 @@ class MothershipAdminInvoicesCest
         $I->seeInDatabase('jos_mothership_invoices', ['id' => $closedInvoiceData['id'], 'status' => 4]);
 
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         // Select both invoices
         $I->click("input[name=checkall-toggle]");
@@ -469,7 +469,7 @@ class MothershipAdminInvoicesCest
         ]);
 
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         // Select the invoice row
         $I->see((string) $invoice['number'], "#j-main-container table.itemList tbody tr td:nth-child(3)");
@@ -497,7 +497,7 @@ class MothershipAdminInvoicesCest
     public function MothershipAddInvoice(AcceptanceTester $I)
     {
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $toolbar = "#toolbar";
         $toolbarNew = "#toolbar-new";
@@ -505,7 +505,7 @@ class MothershipAdminInvoicesCest
         $I->seeElement("{$toolbar} {$toolbarNew}");
         $I->see("New", "{$toolbar} {$toolbarNew} .btn.button-new");
         $I->click("{$toolbar} {$toolbarNew} .btn.button-new");
-        $I->waitForText("Mothership: New Invoice", 20, "h1.page-title");
+        $I->waitForText("Mothership: New Invoice", 10, "h1.page-title");
         $I->wait(5);
 
         $I->see("Save", "#toolbar");
@@ -654,7 +654,7 @@ class MothershipAdminInvoicesCest
             ['name' => 'A different Item', 'description' => 'Test Description', 'hours' => 3, 'minutes' => 45, 'quantity' => 3.75, 'rate' => 70.0, 'subtotal' => 262.50],
         ]);
 
-        $I->waitForText("Mothership: Invoices", 20, "h1.page-title");
+        $I->waitForText("Mothership: Invoices", 10, "h1.page-title");
 
         $I->seeNumberOfElements("#j-main-container table.itemList tbody tr", 2);
 
@@ -703,6 +703,17 @@ class MothershipAdminInvoicesCest
      * @group invoice
      * @group backend-invoice
      */
+    public function MothershipEditInvalidInvoice(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::INVOICE_EDIT_URL, "9999"));
+        $I->waitForText("Invoice not found. Please select a valid invoice.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
+     * @group invoice
+     * @group backend-invoice
+     */
     public function SetInvoiceOpened(AcceptanceTester $I)
     {
         $I->seeInDatabase("jos_mothership_invoices", [
@@ -711,7 +722,7 @@ class MothershipAdminInvoicesCest
             'status' => 1,
         ]);   
         $I->amOnPage(sprintf(self::INVOICE_EDIT_URL, $this->invoiceData['id']));
-        $I->waitForText("Mothership: Edit Invoice", 20, "h1.page-title");
+        $I->waitForText("Mothership: Edit Invoice", 10, "h1.page-title");
 
         $I->seeOptionIsSelected("select#jform_status", "Draft");
         $I->selectOption("select#jform_status", "Opened");

--- a/tests/acceptance/MothershipAdminPaymentsCest.php
+++ b/tests/acceptance/MothershipAdminPaymentsCest.php
@@ -462,6 +462,17 @@ class MothershipAdminPaymentsCest
 
     /**
      * @group backend
+     * @group payment
+     * @group backend-payment
+     */
+    public function MothershipEditInvalidPayment(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::PAYMENT_EDIT_URL, "9999"));
+        $I->waitForText("Payment not found. Please select a valid payment.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
      * @group invoice
      * @group backend-payment
      */

--- a/tests/acceptance/MothershipAdminPaymentsCest.php
+++ b/tests/acceptance/MothershipAdminPaymentsCest.php
@@ -468,7 +468,7 @@ class MothershipAdminPaymentsCest
     public function MothershipEditInvalidPayment(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::PAYMENT_EDIT_URL, "9999"));
-        $I->waitForText("Payment not found. Please select a valid payment.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Payment not found. Please select a valid payment.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminProjectsCest.php
+++ b/tests/acceptance/MothershipAdminProjectsCest.php
@@ -226,7 +226,7 @@ class MothershipAdminProjectsCest
     public function MothershipEditInvalidProject(AcceptanceTester $I)
     {
         $I->amOnPage(sprintf(self::PROJECT_EDIT_URL, "9999"));
-        $I->waitForText("Project not found. Please select a valid project.", 10, "#system-message-container .alert-error");
+        $I->waitForText("Project not found. Please select a valid project.", 10, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminProjectsCest.php
+++ b/tests/acceptance/MothershipAdminProjectsCest.php
@@ -221,6 +221,17 @@ class MothershipAdminProjectsCest
     /**
      * @group backend
      * @group project
+     * @group backend-project
+     */
+    public function MothershipEditInvalidProject(AcceptanceTester $I)
+    {
+        $I->amOnPage(sprintf(self::PROJECT_EDIT_URL, "9999"));
+        $I->waitForText("Project not found. Please select a valid project.", 10, "#system-message-container .alert-error");
+    }
+
+    /**
+     * @group backend
+     * @group project
      * @group scan
      * @group backend-project
      */


### PR DESCRIPTION
# Summary
Makes sure trying to edit an invalid item will redirect the admin to the view all page with an error instead of crashing.

## Changes
- Fixes #146 
- Adds a check on all the admin objects to ensure the item is valid before trying to load the edit page. If its invalid, redirect the user.
- Adds more entries to the `com_mothership.ini`
- Adds tests to check this