### PR TITLE
141 bug prevent duplicate pending payments for an invoice

### DIFF
--- a/.github/workflows/codeception.tests.yml
+++ b/.github/workflows/codeception.tests.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
       - name: Pull Joomla Docker Image from GHCR
         run: docker pull ghcr.io/trevorbicewebdesign/mothership:php8.2-joomla5.3.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-node_modules/
-.env
+/vendor/
+/admin/mothership.xml
+/tests/.env
+/tests/_output/
+/tests/_support/

--- a/admin/src/Helper/PaymentHelper.php
+++ b/admin/src/Helper/PaymentHelper.php
@@ -341,4 +341,28 @@ class PaymentHelper
 
         return $invoices;
     }
+
+    public static function getPendingPayments($invoiceId)
+    {
+        $db = Factory::getContainer()->get(DatabaseDriver::class);
+
+        $query = $db->getQuery(true)
+            ->select('p.*')
+            ->from($db->quoteName('#__mothership_payments', 'p'))
+            ->join('INNER', $db->quoteName('#__mothership_invoice_payment', 'ip') . ' ON ' . $db->quoteName('ip.payment_id') . ' = ' . $db->quoteName('p.id'))
+            ->where($db->quoteName('ip.invoice_id') . ' = :invoice_id')
+            ->where($db->quoteName('p.status') . ' = 1') // Pending
+            ->order($db->quoteName('p.created_at') . ' DESC')
+            ->bind(':invoice_id', $invoiceId);
+
+        $db->setQuery($query);
+
+        try {
+            $payments = $db->loadObjectList();
+        } catch (\Exception $e) {
+            throw new \RuntimeException("Failed to get pending payments: " . $e->getMessage());
+        }
+
+        return $payments;
+    }
 }

--- a/site/language/en-GB/com_mothership.ini
+++ b/site/language/en-GB/com_mothership.ini
@@ -6,4 +6,6 @@ COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_REQUEST="Invalid payment request."
 
 COM_MOTHERSHIP_NO_PAYMENT_HANDLER="No payment handler found."
 
-COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_ID="Invalid payment ID."
+COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_ID="Invalid payment ID"
+
+COM_MOTHERSHIP_ERROR_PENDING_PAYMENT_EXISTS="A pending payment already exists for this invoice."

--- a/site/src/Controller/PaymentController.php
+++ b/site/src/Controller/PaymentController.php
@@ -78,11 +78,12 @@ class PaymentController extends BaseController
             }
 
             $model = $this->getModel('Payment');
+            $payment = $model->getItem($id);
 
             try {
                 $model->cancelPayment($id); // implemented below
                 $app->enqueueMessage(Text::_('COM_MOTHERSHIP_PAYMENT_CANCELED_SUCCESSFULLY'), 'message');
-                $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+                $this->setRedirect(Route::_('index.php?option=com_mothership&view=invoices', false));
                 return;
             } catch (\Throwable $e) {
                 // Be explicit so we don’t mask useful messages in dev

--- a/site/src/Controller/PaymentController.php
+++ b/site/src/Controller/PaymentController.php
@@ -51,4 +51,21 @@ class PaymentController extends BaseController
         // Redirect to the thank you page layout with the correct payment id and invoice id
         $this->setRedirect(Route::_("index.php?option=com_mothership&view=payment&layout=thank-you&id={$payment->id}&invoice_id={$invoice_id}", false));
     }
+
+    public function cancel()
+    {
+        $app = Factory::getApplication();
+        $input = $app->getInput();
+        
+        $id = $input->getInt('id');
+
+        if (!$id) {
+            $app->enqueueMessage(Text::_('COM_MOTHERSHIP_ERROR_INVALID_PAYMENT_ID'), 'error');
+            $this->setRedirect(Route::_('index.php?option=com_mothership&view=payments', false));
+            return;
+        }
+
+        // Redirect to the cancel page layout with the correct payment id and invoice id
+        $this->setRedirect(Route::_("index.php?option=com_mothership&view=payment&layout=cancel&id={$id}", false));
+    }
 }

--- a/site/src/Model/InvoicesModel.php
+++ b/site/src/Model/InvoicesModel.php
@@ -65,7 +65,7 @@ class InvoicesModel extends ListModel
                         GROUP_CONCAT(p.id ORDER BY p.payment_date) AS payment_ids
                 FROM ' . $db->quoteName('#__mothership_invoice_payment', 'ip') . '
                 JOIN ' . $db->quoteName('#__mothership_payments', 'p') . ' ON ip.payment_id = p.id
-                WHERE p.status = 2
+                WHERE ( p.status = 2 OR p.status = 1 )
                 GROUP BY ip.invoice_id) AS pay
                 ON pay.invoice_id = i.id'
             )

--- a/site/src/Model/PaymentModel.php
+++ b/site/src/Model/PaymentModel.php
@@ -5,6 +5,9 @@ namespace TrevorBice\Component\Mothership\Site\Model;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\Database\DatabaseInterface;
+use Joomla\CMS\Language\Text;
+use TrevorBice\Component\Mothership\Site\Helper\LogHelper;
 
 class PaymentModel extends BaseDatabaseModel
 {
@@ -65,6 +68,74 @@ class PaymentModel extends BaseDatabaseModel
         $app = \Joomla\CMS\Factory::getApplication();
         $id = $app->input->getInt('id');
         $this->setState('payment.id', $id);
+    }
+
+    public function cancelPayment(int $paymentId): void
+    {
+        $db = $this->getDatabase();
+
+        // Load the payment
+        $payment = $this->getItem($paymentId);
+
+        if (!$payment) {
+            throw new \RuntimeException("Payment Not Found");
+        }
+
+        // Only pending (1) can be canceled
+        if ((int) $payment->status !== 1) {
+            throw new \RuntimeException("Only Pending Payments Can Be Canceled");
+        }
+
+        // Fetch any linked invoice BEFORE unlinking so we can log it
+        $query = $db->getQuery(true)
+            ->select($db->quoteName('invoice_id'))
+            ->from($db->quoteName('#__mothership_invoice_payment'))
+            ->where($db->quoteName('payment_id') . ' = ' . (int) $paymentId)
+            ->setLimit(1);
+        $invoiceId = (int) $db->setQuery($query)->loadResult();
+
+        $db->transactionStart();
+
+        try {
+            // 1) Update status -> 3 (Canceled)
+            $query = $db->getQuery(true)
+                ->update($db->quoteName('#__mothership_payments'))
+                ->set($db->quoteName('status') . ' = 4')
+                //->set($db->quoteName('modified') . ' = ' . $db->quote(Factory::getDate()->toSql()))
+                ->where($db->quoteName('id') . ' = ' . (int) $paymentId);
+            $db->setQuery($query)->execute();
+
+            // 2) Unlink from invoice(s)
+            $query = $db->getQuery(true)
+                ->delete($db->quoteName('#__mothership_invoice_payment'))
+                ->where($db->quoteName('payment_id') . ' = ' . (int) $paymentId);
+            $db->setQuery($query)->execute();
+
+            // 3) Log it
+            //$userId = (int) Factory::getApplication()->getIdentity()->id ?: 0;
+
+            $meta = [
+                'invoice_id'     => $invoiceId ?: null,
+                'amount'         => (float) $payment->amount,
+                'payment_method' => (string) $payment->payment_method,
+            ];
+            /*
+            LogHelper::add(
+                (int) $payment->client_id,
+                (int) $payment->account_id,
+                $userId,
+                'canceled',
+                'payment',
+                (int) $paymentId,
+                json_encode($meta)
+            );
+            */
+
+            $db->transactionCommit();
+        } catch (\Throwable $e) {
+            $db->transactionRollback();
+            throw $e;
+        }
     }
 
 }

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -66,7 +66,7 @@ use Joomla\CMS\Language\Text;
                         <li><a href="<?php echo Route::_('index.php?option=com_mothership&task=invoice.edit&id=' . $invoice->id); ?>">View</a></li>
                         <?php if($invoice->status === 'Opened' && $invoice->payment_status != 'Pending Confirmation'): ?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Pay</a></li>
-                        <?php elseif($invoice->status ==='Pending Confirmation'):?>
+                        <?php elseif($invoice->payment_status ==='Pending Confirmation'):?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Cancel Pending Payment</a></li>
                         <?php endif; ?>
                     </ul>

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -67,7 +67,7 @@ use Joomla\CMS\Language\Text;
                         <?php if($invoice->status === 'Opened' && $invoice->payment_status != 'Pending Confirmation'): ?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Pay</a></li>
                         <?php elseif($invoice->status ==='Pending Confirmation'):?>
-                        <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Cancel Payment</a></li>
+                        <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Cancel Pending Payment</a></li>
                         <?php endif; ?>
                     </ul>
                     

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -66,6 +66,8 @@ use Joomla\CMS\Language\Text;
                         <li><a href="<?php echo Route::_('index.php?option=com_mothership&task=invoice.edit&id=' . $invoice->id); ?>">View</a></li>
                         <?php if($invoice->status === 'Opened' && $invoice->payment_status != 'Pending Confirmation'): ?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Pay</a></li>
+                        <?php elseif($invoice->status ==='Pending Confirmation'):?>
+                        <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Cancel Payment</a></li>
                         <?php endif; ?>
                     </ul>
                     

--- a/site/tmpl/invoices/default.php
+++ b/site/tmpl/invoices/default.php
@@ -67,7 +67,7 @@ use Joomla\CMS\Language\Text;
                         <?php if($invoice->status === 'Opened' && $invoice->payment_status != 'Pending Confirmation'): ?>
                         <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Pay</a></li>
                         <?php elseif($invoice->payment_status ==='Pending Confirmation'):?>
-                        <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=invoice.payment&id={$invoice->id}"); ?>">Cancel Pending Payment</a></li>
+                        <li><a href="<?php echo Route::_("index.php?option=com_mothership&task=payment.cancel&id={$paymentId}"); ?>">Cancel Pending Payment</a></li>
                         <?php endif; ?>
                     </ul>
                     

--- a/site/tmpl/payment/cancel.php
+++ b/site/tmpl/payment/cancel.php
@@ -1,0 +1,57 @@
+<?php
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+
+$payment = $this->item;
+$statusColor = match ((int) $payment->status) {
+    1 => 'warning',   // Pending
+    2 => 'success',   // Completed
+    3 => 'danger',    // Cancelled
+    4 => 'secondary', // Refunded
+    5 => 'info',      // Other
+    default => 'dark',
+};
+?>
+
+<div class="container my-4">
+    <div class="card shadow-sm">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+            <h4 class="mb-0">Cancel Payment</h4>
+        </div>
+        <div class="card-body">
+            <div class="alert alert-warning" role="alert">
+                <strong>Warning:</strong> Canceling this payment will <u>not</u> void the invoice itself. This only cancels the payment record and allows you to initiate a new payment if needed.
+            </div>
+            <p><strong>Payment ID:</strong> <?php echo htmlspecialchars($payment->id); ?></p>
+            <p><strong>Payment Method:</strong> <?php echo htmlspecialchars($payment->payment_method ?? 'Unknown'); ?></p>
+            <p><strong>Amount:</strong> <span class="text-success fw-bold">$<?php echo number_format($payment->amount, 2); ?></span></p>
+
+                <strong>Status:</strong>
+                <span class="badge bg-<?php echo $statusColor; ?>">
+                    <?php echo $payment->status_text ?? $payment->status; ?>
+                </span>
+            </p>
+            <p>
+                <strong>Payment Date:</strong>
+                <?php echo $payment->payment_date ? htmlspecialchars($payment->payment_date) : '—'; ?>
+            </p>
+            <?php if ((int)$payment->status === 1): // Only allow cancel if pending ?>
+                <form action="<?php echo Route::_('index.php?option=com_mothership&task=payment.cancel'); ?>" method="post">
+                    <input type="hidden" name="id" value="<?php echo (int) $payment->id; ?>">
+                    <?php echo \Joomla\CMS\HTML\HTMLHelper::_('form.token'); ?>
+                    <div class="mb-3">
+                        <button type="submit" class="btn btn-danger"
+                            onclick="return confirm('Are you sure you want to cancel this payment? This action cannot be undone.');">
+                            Cancel Payment
+                        </button>
+                    </div>
+                </form>
+            <?php else: ?>
+                <div class="alert alert-info">
+                    This payment cannot be cancelled. Only pending payments can be cancelled.
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>

--- a/tests/acceptance/MothershipAdminDomainsCest.php
+++ b/tests/acceptance/MothershipAdminDomainsCest.php
@@ -193,7 +193,7 @@ class MothershipAdminDomainsCest
     {
         $I->amOnPage(sprintf(self::DOMAIN_EDIT_URL, "9999"));
         $I->wait(1);
-        $I->waitForText("Domain not found. Please select a valid domain.", 10, "#system-message-container .alert-message");
+        $I->waitForText("Domain not found. Please select a valid domain.", 20, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipAdminProjectsCest.php
+++ b/tests/acceptance/MothershipAdminProjectsCest.php
@@ -228,7 +228,7 @@ class MothershipAdminProjectsCest
     {
         $I->amOnPage(sprintf(self::PROJECT_EDIT_URL, "9999"));
         $I->wait(1);
-        $I->waitForText("Project not found. Please select a valid project.", 10, "#system-message-container .alert-message");
+        $I->waitForText("Project not found. Please select a valid project.", 20, "#system-message-container .alert-message");
     }
 
     /**

--- a/tests/acceptance/MothershipFrontPayByCheckCest.php
+++ b/tests/acceptance/MothershipFrontPayByCheckCest.php
@@ -119,7 +119,7 @@ class MothershipFrontPayByCheckCest
         $I->see("Pay Now");
         $I->see("Total Due: \${$this->invoiceData['total']}");
         // Click Pay By Check
-        $I->click("#payment_method_0");
+        $I->selectOption(['css' => 'input[name="payment_method"]'], 'paybycheck');
         $I->makeScreenshot("account-center-pay-invoice-paybycheck-instructions");
         $I->click("Pay Now");
         $I->wait(1);

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -119,8 +119,8 @@ class MothershipFrontPayByZelleCest
         $I->see("Pay Now");
         $I->see("Total Due: \${$this->invoiceData['total']}");
         // Click Pay By Check
-        $I->click("#payment_method_1");
-        $I->makeScreenshot("account-center-pay-invoice-paybycheck-instructions");
+        $I->selectOption(['css' => 'input[name="payment_method"]'], 'zelle');
+        $I->makeScreenshot("account-center-pay-invoice-zelle-instructions");
         $I->click("Pay Now");
         $I->wait(1);
         $I->waitForText("Thank You", 10, "h1");
@@ -231,7 +231,7 @@ class MothershipFrontPayByZelleCest
         $I->see("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->click("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->wait(1);
-        $I->click("#payment_method_1");
+        $I->selectOption(['css' => 'input[name="payment_method"]'], 'zelle');
         $I->click("Pay Now");
         $I->wait(1);
         $I->waitForText("Thank You", 10, "h1");
@@ -264,18 +264,15 @@ class MothershipFrontPayByZelleCest
             'applied_amount' => $this->invoiceData['total'],
         ]);
         
-        /*
         $I->seeInDatabase("jos_mothership_logs", [
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
             'user_id' => $this->joomlaUserData['id'],            
             'action' => 'initiated',
             'object_type' => 'payment',
-            'object_id' => $this->accountData['id'], 
+            //'object_id' => $this->accountData['id'], 
         ]);
-        */
         
-        /*
         $meta = json_decode($I->grabFromDatabase("jos_mothership_logs", "meta", [
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
@@ -288,8 +285,7 @@ class MothershipFrontPayByZelleCest
         $I->assertEquals($meta->invoice_id,  $this->invoiceData['id']);
         $I->assertEquals($meta->payment_method, "zelle");
         $I->assertEquals($meta->amount, $this->invoiceData['total']);
-        */
-
+        
         $I->click("Return to Payments");
         $I->wait(1);
         $I->waitForText("Payments", 10, "h1");

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -180,4 +180,117 @@ class MothershipFrontPayByZelleCest
         $I->waitForText("Payments", 10, "h1");
     }
 
+    /**
+     * @group frontend
+     * @group payment
+     * @group zelle
+     * @group payment-end-to-end
+     */
+    public function PayInvoiceWithZelleExistingPayment(AcceptanceTester $I)
+    {
+
+        $invoiceData = $I->createMothershipInvoice([
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'total' => '105.00',
+            'number' => '3001',
+            'status' => 1,
+        ]);
+
+        $invoiceItemData = $I->createMothershipInvoiceItem([
+            'invoice_id' => $invoiceData['id'],
+            'name' => 'Test Item 1',
+            'description' => 'Test Description 1',
+            'hours' => '1',
+            'minutes' => '30',
+            'quantity' => '1.5',
+            'rate' => '70.00',
+            'subtotal' => '105.00',
+        ]);
+
+        $I->updateInDatabase("jos_extensions", [
+            'params' => '{"display_name":"Zelle","zelle_email":"test.smith@mailinator.com","zelle_phone":"555 555-5555","instructions":""}',
+        ], [
+            'name' => 'COM_MOTHERSHIP_ZELLE_PLUGIN',
+        ]);
+        $I->updateInDatabase("jos_extensions", [
+            'params' => '{"display_name":"Pay By Check","checkpayee":"Your Company Name"}',
+        ], [
+            'name' => 'COM_MOTHERSHIP_PAYBYCHECK_PLUGIN',
+        ]);
+        // Verify redirection to account center
+        $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
+        $I->waitForText("Invoices", 10, "h1");
+
+        $I->see("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->click("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->wait(1);
+        $I->waitForText("Pay Invoice", 10, "h1");
+        $I->waitForText("Pay Invoice #{$this->invoiceData['number']}", 10, "h1");
+        $I->makeScreenshot("account-center-pay-invoice");
+        codecept_debug($I->grabFromCurrentUrl()); // output the current url into the debug
+        $I->see("Pay Now");
+        $I->see("Total Due: \${$this->invoiceData['total']}");
+        // Click Pay By Check
+        $I->click("#payment_method_1");
+        $I->makeScreenshot("account-center-pay-invoice-paybycheck-instructions");
+        $I->click("Pay Now");
+        $I->wait(1);
+        $I->waitForText("Thank You", 10, "h1");
+        $I->makeScreenshot("account-center-pay-invoice-zelle-thank-you");
+        // Once the user clicks `Pay Now` the payment is created and the user is redirected to the thank you page
+        // The Admin should receive an email regarding the pending payment
+        $I->getEmailBySubject("New Pending Payment for zelle");
+
+        $I->seeInDatabase("jos_mothership_payments", [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'], 
+            'amount' => $this->invoiceData['total'],
+            'payment_method' => 'zelle',
+            'fee_amount' => 0,
+            'status' => 1,
+        ]);
+
+        $payment_id = $I->grabFromDatabase("jos_mothership_payments", "id", [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'], 
+            'amount' => $this->invoiceData['total'],
+            'payment_method' => 'zelle',
+            'fee_amount' => 0,
+            'status' => 1,
+        ]);
+
+        $I->seeInDatabase("jos_mothership_invoice_payment", [
+            'invoice_id' => $this->invoiceData['id'],
+            'payment_id' => $payment_id, 
+            'applied_amount' => $this->invoiceData['total'],
+        ]);
+        
+        $I->seeInDatabase("jos_mothership_logs", [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'user_id' => $this->joomlaUserData['id'],            
+            'action' => 'initiated',
+            'object_type' => 'payment',
+            'object_id' => $this->accountData['id'], 
+        ]);
+        
+        $meta = json_decode($I->grabFromDatabase("jos_mothership_logs", "meta", [
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'user_id' => $this->joomlaUserData['id'],            
+            'action' => 'initiated',
+            'object_type' => 'payment',
+            'object_id' => $this->accountData['id'], 
+        ]));
+        codecept_debug($meta);
+        $I->assertEquals($meta->invoice_id,  $this->invoiceData['id']);
+        $I->assertEquals($meta->payment_method, "zelle");
+        $I->assertEquals($meta->amount, $this->invoiceData['total']);
+
+        $I->click("Return to Payments");
+        $I->wait(1);
+        $I->waitForText("Payments", 10, "h1");
+    }
+
 }

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -221,14 +221,14 @@ class MothershipFrontPayByZelleCest
         $I->click("Cancel Pending Payment", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->wait(1);
         $I->waitForText("Cancel Payment", 10, "h4");
-        $I->makeScreenshot("account-center-pay-invoice");
+        $I->makeScreenshot("account-center-pay-invoice-zelle");
         codecept_debug($I->grabFromCurrentUrl()); // output the current url into the debug
-        $I->see("Pay Now");
-        $I->see("Total Due: \${$this->invoiceData['total']}");
-        // Click Pay By Check
-        $I->click("#payment_method_1");
-        $I->makeScreenshot("account-center-pay-invoice-paybycheck-instructions");
-        $I->click("Pay Now");
+        $I->click("Cancel Payment");
+        // Accept javascript confirm
+        $I->acceptPopup();
+        $I->wait(2);
+        codecept_debug($I->grabFromCurrentUrl()); // output the current url into the debug
+        $I->click("Pay Now", "#selected-instructions button");
         $I->wait(1);
         $I->waitForText("Thank You", 10, "h1");
         $I->makeScreenshot("account-center-pay-invoice-zelle-thank-you");

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -228,7 +228,11 @@ class MothershipFrontPayByZelleCest
         $I->acceptPopup();
         $I->wait(2);
         codecept_debug($I->grabFromCurrentUrl()); // output the current url into the debug
-        $I->click("Pay Now", "#selected-instructions button");
+        $I->see("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->click("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->wait(1);
+        $I->click("#payment_method_1");
+        $I->click("Pay Now");
         $I->wait(1);
         $I->waitForText("Thank You", 10, "h1");
         $I->makeScreenshot("account-center-pay-invoice-zelle-thank-you");
@@ -260,6 +264,7 @@ class MothershipFrontPayByZelleCest
             'applied_amount' => $this->invoiceData['total'],
         ]);
         
+        /*
         $I->seeInDatabase("jos_mothership_logs", [
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
@@ -268,7 +273,9 @@ class MothershipFrontPayByZelleCest
             'object_type' => 'payment',
             'object_id' => $this->accountData['id'], 
         ]);
+        */
         
+        /*
         $meta = json_decode($I->grabFromDatabase("jos_mothership_logs", "meta", [
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
@@ -281,6 +288,7 @@ class MothershipFrontPayByZelleCest
         $I->assertEquals($meta->invoice_id,  $this->invoiceData['id']);
         $I->assertEquals($meta->payment_method, "zelle");
         $I->assertEquals($meta->amount, $this->invoiceData['total']);
+        */
 
         $I->click("Return to Payments");
         $I->wait(1);

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -159,7 +159,7 @@ class MothershipFrontPayByZelleCest
             'user_id' => $this->joomlaUserData['id'],            
             'action' => 'initiated',
             'object_type' => 'payment',
-            'object_id' => $this->accountData['id'], 
+            'object_id' => $payment_id,
         ]);
         
         $meta = json_decode($I->grabFromDatabase("jos_mothership_logs", "meta", [
@@ -168,7 +168,7 @@ class MothershipFrontPayByZelleCest
             'user_id' => $this->joomlaUserData['id'],            
             'action' => 'initiated',
             'object_type' => 'payment',
-            'object_id' => $this->accountData['id'], 
+            'object_id' => $payment_id,
         ]));
         codecept_debug($meta);
         $I->assertEquals($meta->invoice_id,  $this->invoiceData['id']);
@@ -270,7 +270,7 @@ class MothershipFrontPayByZelleCest
             'user_id' => $this->joomlaUserData['id'],            
             'action' => 'initiated',
             'object_type' => 'payment',
-            //'object_id' => $this->accountData['id'], 
+            'object_id' => $payment_id, 
         ]);
         
         $meta = json_decode($I->grabFromDatabase("jos_mothership_logs", "meta", [
@@ -279,8 +279,9 @@ class MothershipFrontPayByZelleCest
             'user_id' => $this->joomlaUserData['id'],            
             'action' => 'initiated',
             'object_type' => 'payment',
-            'object_id' => $this->accountData['id'], 
+            'object_id' => $payment_id, 
         ]));
+
         codecept_debug($meta);
         $I->assertEquals($meta->invoice_id,  $this->invoiceData['id']);
         $I->assertEquals($meta->payment_method, "zelle");

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -220,8 +220,7 @@ class MothershipFrontPayByZelleCest
         $I->see("Cancel Pending Payment", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->click("Cancel Pending Payment", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->wait(1);
-        $I->waitForText("Pay Invoice", 10, "h1");
-        $I->waitForText("Pay Invoice #{$this->invoiceData['number']}", 10, "h1");
+        $I->waitForText("Cancel Payment", 10, "h4");
         $I->makeScreenshot("account-center-pay-invoice");
         codecept_debug($I->grabFromCurrentUrl()); // output the current url into the debug
         $I->see("Pay Now");

--- a/tests/acceptance/MothershipFrontPayByZelleCest.php
+++ b/tests/acceptance/MothershipFrontPayByZelleCest.php
@@ -189,23 +189,18 @@ class MothershipFrontPayByZelleCest
     public function PayInvoiceWithZelleExistingPayment(AcceptanceTester $I)
     {
 
-        $invoiceData = $I->createMothershipInvoice([
+        $paymentData = $I->createMothershipPayment([
             'client_id' => $this->clientData['id'],
             'account_id' => $this->accountData['id'],
-            'total' => '105.00',
-            'number' => '3001',
+            'amount' => $this->invoiceData['total'],
+            'payment_method' => 'zelle',
+            'fee_amount' => 0,
             'status' => 1,
         ]);
-
-        $invoiceItemData = $I->createMothershipInvoiceItem([
-            'invoice_id' => $invoiceData['id'],
-            'name' => 'Test Item 1',
-            'description' => 'Test Description 1',
-            'hours' => '1',
-            'minutes' => '30',
-            'quantity' => '1.5',
-            'rate' => '70.00',
-            'subtotal' => '105.00',
+        $invoicePaymentData = $I->createMothershipInvoicePayment([
+            'invoice_id' => $this->invoiceData['id'],
+            'payment_id' => $paymentData['id'],
+            'applied_amount' => $this->invoiceData['total'],
         ]);
 
         $I->updateInDatabase("jos_extensions", [
@@ -222,8 +217,8 @@ class MothershipFrontPayByZelleCest
         $I->amOnPage(self::INVOICES_VIEW_ALL_URL);
         $I->waitForText("Invoices", 10, "h1");
 
-        $I->see("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
-        $I->click("Pay", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->see("Cancel Pending Payment", "table#invoicesTable tbody tr td:nth-child(8)");
+        $I->click("Cancel Pending Payment", "table#invoicesTable tbody tr td:nth-child(8)");
         $I->wait(1);
         $I->waitForText("Pay Invoice", 10, "h1");
         $I->waitForText("Pay Invoice #{$this->invoiceData['number']}", 10, "h1");

--- a/tests/integration/MothershipPaymentHelperTest.php
+++ b/tests/integration/MothershipPaymentHelperTest.php
@@ -234,4 +234,42 @@ class MothershipPaymentHelperTest extends \Codeception\Test\Unit
         }
 
     }
+
+    public function testGetPendingPayments()
+    {
+        $invoiceData = $this->tester->createMothershipInvoice([
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'total' => 100.00,
+            'number' => '1000',
+            'status' => 2,
+            'due_date' => date('Y-m-d', strtotime('-1 day')),
+        ]);
+        $invoiceId = $invoiceData['id'];
+        $paymentData = $this->tester->createMothershipPayment([
+            'client_id' => $this->clientData['id'],
+            'account_id' => $this->accountData['id'],
+            'amount' => 100.00,
+            'payment_date' => date('Y-m-d H:i:s'),
+            'fee_amount' => 6.00,
+            'fee_passed_on' => 0,
+            'payment_method' => 'paypal',
+            'transaction_id' => '123456',
+            'status' => 1,
+        ]);
+        $paymentId = $paymentData['id'];
+        $invoicePaymentData = $this->tester->createMothershipInvoicePayment([
+            'invoice_id' => $invoiceId,
+            'payment_id' => $paymentId,
+            'applied_amount' => 100.00,
+        ]);
+
+        $payments = PaymentHelper::getPendingPayments($invoiceData['id']);
+        codecept_debug("PENDING PAYMENTS");
+        codecept_debug($payments);
+
+        $this->assertIsArray($payments);
+        $this->assertNotEmpty($payments);
+
+    }
 }


### PR DESCRIPTION
# Summary
Prevent duplicate payments from being created. User needs to cancel an existing payment before a new payment can be generated. This should prevent duplicate payments.